### PR TITLE
[FEATURE] 구글 소셜 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.github.cdimascio:dotenv-java:3.1.0'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/knu/sosuso/capstone/config/CorsMvcConfig.java
+++ b/src/main/java/com/knu/sosuso/capstone/config/CorsMvcConfig.java
@@ -1,0 +1,17 @@
+package com.knu.sosuso.capstone.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+
+        corsRegistry.addMapping("/**")
+                .exposedHeaders("Set-Cookie")
+                .allowedOrigins("http://localhost:3000");
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/config/SecurityConfig.java
+++ b/src/main/java/com/knu/sosuso/capstone/config/SecurityConfig.java
@@ -1,0 +1,55 @@
+package com.knu.sosuso.capstone.config;
+
+import com.knu.sosuso.capstone.oauth2.CustomSuccessHandler;
+import com.knu.sosuso.capstone.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomSuccessHandler customSuccessHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        // csrf disable
+        http
+                .csrf((auth) -> auth.disable());
+
+        // form 로그인 방식 disable
+        http
+                .formLogin((auth) -> auth.disable());
+
+        // HTTP Basic 인증 방식 disable
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        // oauth2
+        http
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService))
+                        .successHandler(customSuccessHandler));
+
+        // 경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/").permitAll()
+                        .anyRequest().authenticated());
+
+        // 세션 설정: STATELESS
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/User.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/User.java
@@ -1,0 +1,55 @@
+package com.knu.sosuso.capstone.domain;
+
+import com.knu.sosuso.capstone.dto.request.AuthRequest;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Table(name = "user")
+@Entity
+public class User extends BaseEntity {
+
+    @Column(name = "sub")
+    private String sub;
+
+    @Column(name = "email")
+    private String email;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "role")
+    private String role;
+
+    @Column(name = "picture")
+    private String picture;
+
+    protected User(){
+    }
+
+    @Builder
+    public User(String sub, String email, String name, String role, String picture) {
+        this.sub = sub;
+        this.email = email;
+        this.name = name;
+        this.role = role;
+        this.picture = picture;
+    }
+
+    public static User signUp(AuthRequest authRequest) {
+        return User.builder()
+                .sub(authRequest.sub())
+                .email(authRequest.email())
+                .name(authRequest.name())
+                .role(authRequest.role())
+                .picture(authRequest.picture())
+                .build();
+    }
+
+    public void signIn(AuthRequest authRequest) {
+        this.email = authRequest.email();
+        this.name = authRequest.name();
+        this.picture = authRequest.picture();
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/dto/CustomOAuth2User.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/CustomOAuth2User.java
@@ -1,0 +1,44 @@
+package com.knu.sosuso.capstone.dto;
+
+import com.knu.sosuso.capstone.dto.request.AuthRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final AuthRequest authRequest;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return authRequest.role();
+            }
+        });
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return authRequest.name();
+    }
+
+    public String getSub() {
+            return authRequest.sub();
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/dto/request/AuthRequest.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/request/AuthRequest.java
@@ -1,0 +1,10 @@
+package com.knu.sosuso.capstone.dto.request;
+
+public record AuthRequest(
+        String sub,
+        String email,
+        String name,
+        String role,
+        String picture
+) {
+}

--- a/src/main/java/com/knu/sosuso/capstone/dto/response/GoogleResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/response/GoogleResponse.java
@@ -1,0 +1,37 @@
+package com.knu.sosuso.capstone.dto.response;
+
+import java.util.Map;
+
+public class GoogleResponse implements OAuth2Response {
+
+    private Map<String, Object> attribute;
+
+    public GoogleResponse(Map<String, Object> attribute) {
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+
+    @Override
+    public String getPicture() {
+        return attribute.get("picture").toString();
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/dto/response/OAuth2Response.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/response/OAuth2Response.java
@@ -1,0 +1,18 @@
+package com.knu.sosuso.capstone.dto.response;
+
+public interface OAuth2Response {
+    // 제공자 (ex. google, naver, kakao, ...)
+    String getProvider();
+
+    // 제공자에서 발급해주는 아이디(번호)
+    String getProviderId();
+
+    // 이메일
+    String getEmail();
+
+    // 사용자 실명(설정한 이름)
+    String getName();
+
+    // 프로필 사진
+    String getPicture();
+}

--- a/src/main/java/com/knu/sosuso/capstone/jwt/JwtFilter.java
+++ b/src/main/java/com/knu/sosuso/capstone/jwt/JwtFilter.java
@@ -1,0 +1,73 @@
+package com.knu.sosuso.capstone.jwt;
+
+import com.knu.sosuso.capstone.dto.CustomOAuth2User;
+import com.knu.sosuso.capstone.dto.request.AuthRequest;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String authorization = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            System.out.println(cookie.getName());
+            if (cookie.getName().equals("Authorization")) {
+                authorization = cookie.getValue();
+            }
+        }
+        if (authorization == null) {
+            System.out.println("token null");
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+        // 토큰
+        String token = authorization;
+
+        // 토큰 소멸 시간 검증
+        if (jwtUtil.isExpired(token)) {
+            System.out.println("token expired");
+            filterChain.doFilter(request, response);
+
+            // 조건이 해당되면 메서드 종료 (필수)
+            return;
+        }
+
+        // 토큰에서 user 정보 획득
+        String sub = jwtUtil.getSub(token);
+        String email = jwtUtil.getEmail(token);
+        String name = jwtUtil.getName(token);
+        String role = jwtUtil.getRole(token);
+        String picture = jwtUtil.getPicture(token);
+
+        // userDto를 생성하여 값 set
+        AuthRequest authRequest = new AuthRequest(sub, email, name, role, picture);
+
+        // UserDetails에 회원 정보 객체 담기
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(authRequest);
+
+        // 스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
+        // 세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/jwt/JwtUtil.java
+++ b/src/main/java/com/knu/sosuso/capstone/jwt/JwtUtil.java
@@ -1,0 +1,54 @@
+package com.knu.sosuso.capstone.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private SecretKey secretKey;
+
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getSub(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getEmail(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
+    }
+
+    public String getName(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("name", String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public String getPicture(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("picture", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String sub, String role, Long expireMs) {
+        return Jwts.builder()
+                .claim("sub", sub)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expireMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/knu/sosuso/capstone/oauth2/CustomSuccessHandler.java
@@ -1,0 +1,51 @@
+package com.knu.sosuso.capstone.oauth2;
+
+import com.knu.sosuso.capstone.jwt.JwtUtil;
+import com.knu.sosuso.capstone.dto.CustomOAuth2User;
+import io.jsonwebtoken.io.IOException;
+import io.jsonwebtoken.io.SerialException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+@RequiredArgsConstructor
+@Component
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, SerialException, java.io.IOException {
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+
+        String username = customUserDetails.getSub();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+        String token = jwtUtil.createJwt(username, role, 60*60*60L);
+
+        response.addCookie(createCookie("Authorization", token));
+        response.sendRedirect("http://localhost:3000/");
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60*60*60);
+//        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/repository/UserRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.knu.sosuso.capstone.repository;
+
+import com.knu.sosuso.capstone.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findBySub(String username);
+}

--- a/src/main/java/com/knu/sosuso/capstone/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/CustomOAuth2UserService.java
@@ -1,0 +1,35 @@
+package com.knu.sosuso.capstone.service;
+
+import com.knu.sosuso.capstone.domain.User;
+import com.knu.sosuso.capstone.dto.CustomOAuth2User;
+import com.knu.sosuso.capstone.dto.request.AuthRequest;
+import com.knu.sosuso.capstone.dto.response.GoogleResponse;
+import com.knu.sosuso.capstone.dto.response.OAuth2Response;
+import com.knu.sosuso.capstone.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        System.out.println("oAuth2User = " + oAuth2User);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response;
+        if (registrationId.equals("google")) {
+            oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+        } else {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,23 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-name: google
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: ${REDIRECT_URI}
+            scope:
+              - email
+              - profile
+
+  jwt:
+    secret: ${JWT_SECRET}
+
 youtube:
   api:
     key: AIzaSyCWWWB5MWaGQr3ygbqYeurqyReU4RnNC5o # 키 재발급 필요


### PR DESCRIPTION
- resolves #7 
---
### 🚀 어떤 기능을 구현했나요?
- 구글 OAuth2 인증 기반 소셜 로그인 기능을 구현했습니다.
- JWT 기반으로 AccessToken을 통해 사용자 정보(sub, email, name, picture(profile image))를 조회합니다.
- 신규 회원일 경우 회원가입 처리, 기존 회원일 경우 로그인 처리 및 JWT를 발급합니다.

### 🔥 어떻게 해결했나요?
- JWT 너무 어려워서 강의를 많이 참고했습니다 .. 🥲

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 신규 회원과 기존 회원을 구분하여 각 기능을 처리하는 로직을 다시 고민해보고 싶어요.

### 📚 참고 자료, 할 말
- 테스트 시 구글 redirect uri와 로컬 서버 주소가 일치하는지 꼭 확인해주세요 ~~
- 참고 영상:  https://youtube.com/playlist?list=PLJkjrxxiBSFALedMwcqDw_BPaJ3qqbWeB&si=wumT8ks4jKI_TWAP (개발자 유미님 스프링 OAuth2 클라이언트 JWT)
