### PR TITLE
[FEAT] 채널 검색 응답 필드 추가

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/config/SecurityConfig.java
+++ b/src/main/java/com/knu/sosuso/capstone/config/SecurityConfig.java
@@ -79,6 +79,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers(
                                 "/",
+                                "/api/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html"

--- a/src/main/java/com/knu/sosuso/capstone/config/SecurityConfig.java
+++ b/src/main/java/com/knu/sosuso/capstone/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/", "/api/**").permitAll()  // 테스트를 위한 임시 수정
                         .anyRequest().authenticated());
 
         // 세션 설정: STATELESS

--- a/src/main/java/com/knu/sosuso/capstone/dto/response/ChannelApiResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/response/ChannelApiResponse.java
@@ -8,9 +8,11 @@ public record ChannelApiResponse(
     public record ChannelData(
             String channelId,
             String title,
+            String handle,
             String description,
             String thumbnailUrl,
-            String subscriberCount  // 구독자 수
+            String subscriberCount,
+            boolean isSubscribed
     ) {
     }
 }

--- a/src/main/java/com/knu/sosuso/capstone/service/ChannelService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/ChannelService.java
@@ -97,6 +97,7 @@ public class ChannelService {
                             String channelId = channel.path("id").asText();
                             JsonNode snippetNode = channel.path("snippet");
                             String title = snippetNode.path("title").asText();
+                            String handle = snippetNode.path("customUrl").asText();
                             String description = snippetNode.path("description").asText();
 
                             JsonNode thumbnailsNode = snippetNode.path("thumbnails");
@@ -107,8 +108,10 @@ public class ChannelService {
                             JsonNode statisticsNode = channel.path("statistics");
                             String subscriberCountStr = statisticsNode.path("subscriberCount").asText();
 
+                            boolean isSubscribed = false;  // 추후에 변동 예정
+
                             results.add(new ChannelApiResponse.ChannelData(
-                                    channelId, title, description, thumbnailUrl, subscriberCountStr));
+                                    channelId, title, handle, description, thumbnailUrl, subscriberCountStr, isSubscribed));
                         }
                     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,4 +37,4 @@ spring:
 
 youtube:
   api:
-    key: AIzaSyCWWWB5MWaGQr3ygbqYeurqyReU4RnNC5o # 키 재발급 필요
+    key: ${YOUTUBE_API_KEY}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #15 
---
### 🚀 어떤 기능을 구현했나요?
- 유튜브 채널 검색 결과 응답에 handle과 isSubscribed 필드를 추가했습니다.
- 프론트에서 채널명 옆에 @핸들을 보여주고, 관심 채널 여부를 기반으로 버튼 토글이 가능해집니다.

### 🔥 어떻게 해결했나요?
- YouTube Data API의 'snippet.customUrl'을 파싱해 handle 값으로 매핑하였습니다.
- 관심 채널 여부는 현재 boolean 타입으로 'isSubscribed' 필드에 포함하여 관심 채널 기능이 완료된 후에 수정할 생각입니다.
- develop 브랜치와 병합 중 발생한 충돌(SecurityConfig, JwtFilter 등)을 수동 해결하였습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 채널 검색 응답 필드에 추가로 변동이 필요한 부분이 있는지 확인 부탁드립니다.
- JWT 인증 없이 API 테스트를 위해 `/api/**` 경로를 permitAll에 임시 추가하였습니다. SecurityConfig.java 파일 확인 부탁드립니다.

### 📚 참고 자료, 할 말
- YouTube Data API v3 `channels?part=snippet` → `customUrl` 기반으로 핸들 가져왔습니다.
- 추후 관심 채널 정보 실시간 조회 연동을 위해 DB 연동을 할 계획입니다.
