### PR TITLE
[FIX] Authorization 쿠키 null 값 체크

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/jwt/JwtFilter.java
+++ b/src/main/java/com/knu/sosuso/capstone/jwt/JwtFilter.java
@@ -33,12 +33,15 @@ public class JwtFilter extends OncePerRequestFilter {
 
         String authorization = null;
         Cookie[] cookies = request.getCookies();
-        for (Cookie cookie : cookies) {
-            System.out.println(cookie.getName());
-            if (cookie.getName().equals("Authorization")) {
-                authorization = cookie.getValue();
+        if (cookies != null) { // 임시
+            for (Cookie cookie : cookies) {
+                System.out.println(cookie.getName());
+                if (cookie.getName().equals("Authorization")) {
+                    authorization = cookie.getValue();
+                }
             }
         }
+
         if (authorization == null) {
             System.out.println("token null");
             filterChain.doFilter(request, response);


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #28 
---
### 🚀 어떤 기능을 구현했나요?
- Authorization 쿠키 누락 시 서버 오류 발생하던 문제를 해결했습니다.
- 쿠키가 null일 경우를 처리하도록 JwtFilter 로직을 수정했습니다.

### 🔥 어떻게 해결했나요?
- request.getCookie()가 null인지를 체크하여 반복문이 실행될 수 있도록 수정했습니다.
- Authorization 쿠키가 null일 경우 인증 로직을 건너뛰도록 수정했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
-
