### PR TITLE
[FEAT] YouTube 댓글 DB 저장 기능 구현

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/Comment.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/Comment.java
@@ -1,0 +1,48 @@
+package com.knu.sosuso.capstone.domain;
+
+import com.knu.sosuso.capstone.domain.enums.Emotion;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "comment")
+@NoArgsConstructor
+public class Comment extends BaseEntity{
+
+    @Column(name = "video_id", nullable = false)
+    private String videoId;
+
+    @Column(name = "api_comment_id", nullable = false)
+    private String apiCommentId;
+
+    @Column(name = "comment_content", columnDefinition = "TEXT")
+    private String commentContent;
+
+    @Column(name = "like_count")
+    private Integer likeCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "emotion")
+    private Emotion emotion;
+
+    @Column(name = "writer")
+    private String writer;
+
+    @Column(name = "written_at")
+    private String writtenAt;
+
+    @Builder
+    public Comment(String videoId, String apiCommentId, String commentContent,
+                   Integer likeCount, Emotion emotion, String writer, String writtenAt) {
+        this.videoId = videoId;
+        this.apiCommentId = apiCommentId;
+        this.commentContent = commentContent;
+        this.likeCount = likeCount;
+        this.emotion = emotion;
+        this.writer = writer;
+        this.writtenAt = writtenAt;
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/enums/Emotion.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/enums/Emotion.java
@@ -1,0 +1,7 @@
+package com.knu.sosuso.capstone.domain.enums;
+
+public enum Emotion {
+    positive,
+    negative,
+    other
+}

--- a/src/main/java/com/knu/sosuso/capstone/dto/response/CommentApiResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/response/CommentApiResponse.java
@@ -9,6 +9,7 @@ public record CommentApiResponse(
             String authorName,                       // 작성자 이름
             String commentText,                      // 댓글 본문
             int likeCount,                           // 좋아요 수
+            String emotion,                          // 감정 분석
             String publishedAt                       // 작성 시각
     ) {
     }

--- a/src/main/java/com/knu/sosuso/capstone/repository/CommentRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/repository/CommentRepository.java
@@ -1,0 +1,21 @@
+package com.knu.sosuso.capstone.repository;
+
+import com.knu.sosuso.capstone.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    // 특정 비디오의 댓글들 조회 (좋아요 수 내림차순)
+    List<Comment> findByVideoIdOrderByLikeCountDesc(String videoId);
+
+    // 중복 댓글 체크
+    boolean existsByApiCommentId(String apiCommentId);
+
+    // 비디오별 댓글 삭제
+    void deleteByVideoId(String videoId);
+
+}

--- a/src/main/java/com/knu/sosuso/capstone/service/CommentService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/CommentService.java
@@ -3,17 +3,22 @@ package com.knu.sosuso.capstone.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.knu.sosuso.capstone.config.ApiConfig;
+import com.knu.sosuso.capstone.domain.Comment;
+import com.knu.sosuso.capstone.domain.enums.Emotion;
 import com.knu.sosuso.capstone.dto.response.CommentApiResponse;
 import com.knu.sosuso.capstone.dto.response.CommentApiResponse.CommentData;
+import com.knu.sosuso.capstone.repository.CommentRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class CommentService {
@@ -25,11 +30,13 @@ public class CommentService {
     private final RestTemplate restTemplate;
     private final String apiKey;
     private final ObjectMapper objectMapper;
+    private final CommentRepository commentRepository;
 
-    public CommentService(ApiConfig config, RestTemplate restTemplate) {
+    public CommentService(ApiConfig config, RestTemplate restTemplate, CommentRepository commentRepository) {
         this.apiKey = config.getKey();
         this.restTemplate = restTemplate;
         this.objectMapper = new ObjectMapper();
+        this.commentRepository = commentRepository;
     }
 
     public CommentApiResponse getCommentInfo(String videoId) {
@@ -63,6 +70,99 @@ public class CommentService {
             logger.error("댓글 정보 조회 실패: videoId={}, error={}", videoId, e.getMessage(), e);
             throw new RuntimeException("댓글 정보 조회 중 오류 발생", e);
         }
+    }
+
+    /**
+     * 댓글 조회 + DB 저장 (통합 메서드)
+     */
+    public CommentApiResponse getCommentInfoAndSave(String videoId) {
+        CommentApiResponse commentResponse = getCommentInfo(videoId);
+
+        try {
+            int savedCount = saveCommentsToDb(videoId, commentResponse.allComments());
+            logger.info("댓글 DB 저장 완료: videoId={}, 저장된 개수={}", videoId, savedCount);
+        } catch (Exception e) {
+            logger.error("댓글 DB 저장 실패: videoId={}, error={}", videoId, e.getMessage());
+        }
+
+        return commentResponse;
+    }
+
+    /**
+     * 댓글 리스트를 DB에 저장
+     */
+    @Transactional
+    public int saveCommentsToDb(String videoId, List<CommentData> comments) {
+        if (videoId == null || videoId.trim().isEmpty()) {
+            throw new IllegalArgumentException("비디오 ID는 필수입니다");
+        }
+
+        if (comments == null || comments.isEmpty()) {
+            logger.info("저장할 댓글이 없습니다: videoId={}", videoId);
+            return 0;
+        }
+
+        logger.info("댓글 DB 저장 시작: videoId={}, 댓글수={}", videoId, comments.size());
+
+        try {
+            List<Comment> commentsToSave = comments.stream()
+                    .map(commentData -> Comment.builder()
+                            .videoId(videoId)
+                            .apiCommentId(generateApiCommentId(videoId, commentData))
+                            .commentContent(commentData.commentText())
+                            .likeCount(commentData.likeCount())
+                            .emotion(Emotion.other) // 임시로 other 설정
+                            .writer(commentData.authorName())
+                            .writtenAt(commentData.publishedAt())
+                            .build())
+                    .filter(comment -> !commentRepository.existsByApiCommentId(comment.getApiCommentId()))
+                    .collect(Collectors.toList());
+
+            List<Comment> savedComments = commentRepository.saveAll(commentsToSave);
+
+            logger.info("댓글 DB 저장 완료: videoId={}, 저장={}, 중복 제외={}",
+                    videoId, savedComments.size(), comments.size() - savedComments.size());
+
+            return savedComments.size();
+
+        } catch (Exception e) {
+            logger.error("댓글 DB 저장 실패: videoId={}, error={}", videoId, e.getMessage(), e);
+            throw new RuntimeException("댓글 저장 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 기존 댓글 삭제 후 새로 저장
+     */
+    @Transactional
+    public int replaceCommentsInDb(String videoId, List<CommentData> comments) {
+        logger.info("댓글 교체 시작: videoId={}", videoId);
+
+        // 기존 댓글 삭제
+        commentRepository.deleteByVideoId(videoId);
+
+        // 새 댓글 저장
+        return saveCommentsToDb(videoId, comments);
+    }
+
+    /**
+     * DB에서 댓글 조회
+     */
+    @Transactional(readOnly = true)
+    public CommentApiResponse getCommentsFromDb(String videoId) {
+        List<Comment> dbComments = commentRepository.findByVideoIdOrderByLikeCountDesc(videoId);
+
+        List<CommentData> commentDataList = dbComments.stream()
+                .map(comment -> new CommentData(
+                        comment.getWriter(),
+                        comment.getCommentContent(),
+                        comment.getLikeCount(),
+                        comment.getEmotion().name().toLowerCase(), // enum을 문자열로 변환
+                        comment.getWrittenAt()
+                ))
+                .collect(Collectors.toList());
+
+        return new CommentApiResponse(commentDataList);
     }
 
     private List<CommentData> fetchAllComments(String videoId) {
@@ -136,7 +236,6 @@ public class CommentService {
         return comments;
     }
 
-
     private CommentData extractCommentData(JsonNode item) {
         try {
             JsonNode snippet = item.path("snippet");
@@ -159,7 +258,10 @@ public class CommentService {
             int likeCount = commentSnippet.path("likeCount").asInt(0);
             String publishedAt = commentSnippet.path("publishedAt").asText();
 
-            return new CommentData(authorName, commentText, likeCount, publishedAt);
+            // 추후 변동 예정
+            String emotion = "other";
+
+            return new CommentData(authorName, commentText, likeCount, emotion, publishedAt);
 
         } catch (Exception e) {
             logger.warn("댓글 파싱 실패: {}", e.getMessage());
@@ -172,5 +274,11 @@ public class CommentService {
                 .map(String::trim)
                 .filter(token -> !token.isEmpty())
                 .isPresent();
+    }
+
+    private String generateApiCommentId(String videoId, CommentData commentData) {
+        String combined = videoId + commentData.authorName() +
+                commentData.publishedAt() + commentData.commentText();
+        return String.valueOf(combined.hashCode());
     }
 }

--- a/src/main/java/com/knu/sosuso/capstone/service/SearchService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/SearchService.java
@@ -60,7 +60,7 @@ public class SearchService {
         logger.info("비디오 검색 시작: videoId={}", videoId);
 
         try {
-            CommentApiResponse commentInfo = commentService.getCommentInfo(videoId);
+            CommentApiResponse commentInfo = commentService.getCommentInfoAndSave(videoId);
             VideoApiResponse videoInfo = videoService.getVideoInfo(videoId, commentInfo.allComments().size());
 
             logger.info("비디오 검색 완료: videoId={}, 댓글수={}",

--- a/src/main/java/com/knu/sosuso/capstone/service/TrendingService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/TrendingService.java
@@ -46,7 +46,7 @@ public class TrendingService {
                 try {
                     log.debug("비디오 정보 조회 중: videoId={}", videoId);
 
-                    CommentApiResponse commentInfo = commentService.getCommentInfo(videoId);
+                    CommentApiResponse commentInfo = commentService.getCommentInfoAndSave(videoId);
 
                     VideoApiResponse videoInfo = videoService.getVideoInfo(videoId, commentInfo.allComments().size());
 


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #31 
---
### 🚀 어떤 기능을 구현했나요?
- YouTube API에서 수집한 댓글을 데이터베이스에 저장하는 기능을 구현했습니다.

### 🔥 어떻게 해결했나요?
- YouTube API로 댓글 수집 및 DB 자동 저장
- API 댓글 ID 해시로 중복 댓글 필터링

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 댓글 ID 해시 메서드 generateApiCommentId를 확인해주세요.
- 테스트를 해보고 DB에 저장되는 데이터 형태를 확인해주세요.
- CommentService의 추가된 메서드들 확인해주세요.

### 📚 참고 자료, 할 말
- 정신이 몽롱한 상태에서 급하게 해서 추후에 또 수정해야 할 것 같습니다. 예린님이 테스트 해보시고 고칠 부분 있으면 알려주세요..