### PR TITLE
[FEATURE] Swagger 세팅

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/swagger/annotation/ErrorCode400.java
+++ b/src/main/java/com/knu/sosuso/capstone/swagger/annotation/ErrorCode400.java
@@ -1,0 +1,25 @@
+package com.knu.sosuso.capstone.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.http.ProblemDetail;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+        responseCode = "400",
+        description = "클라이언트 입력 오류",
+        content = @Content(schema = @Schema(implementation = ProblemDetail.class))
+)
+public @interface ErrorCode400 {
+
+    @AliasFor(annotation = ApiResponse.class, attribute = "description")
+    String description() default "클라이언트 입력 오류";
+}

--- a/src/main/java/com/knu/sosuso/capstone/swagger/annotation/ErrorCode404.java
+++ b/src/main/java/com/knu/sosuso/capstone/swagger/annotation/ErrorCode404.java
@@ -1,0 +1,25 @@
+package com.knu.sosuso.capstone.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.http.ProblemDetail;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+        responseCode = "404",
+        content = @Content(schema = @Schema(implementation = ProblemDetail.class))
+)
+public @interface ErrorCode404 {
+
+    @AliasFor(annotation = ApiResponses.class, attribute = "description")
+    String description();
+}

--- a/src/main/java/com/knu/sosuso/capstone/swagger/annotation/ErrorCode500.java
+++ b/src/main/java/com/knu/sosuso/capstone/swagger/annotation/ErrorCode500.java
@@ -1,0 +1,21 @@
+package com.knu.sosuso.capstone.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ProblemDetail;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+        responseCode = "500",
+        description = "서버 오류",
+        content = @Content(schema = @Schema(implementation = ProblemDetail.class))
+)
+public @interface ErrorCode500 {
+}

--- a/src/main/java/com/knu/sosuso/capstone/swagger/config/SwaggerConfig.java
+++ b/src/main/java/com/knu/sosuso/capstone/swagger/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package com.knu.sosuso.capstone.swagger.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Capstone API")
+                .description("우리들의 API들 .. ^0^")
+                .version("1.0.0");
+    }
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #19 
---
### 🚀 어떤 기능을 구현했나요?
- SwaggerConfig를 추가하여 OpenAPI 문서의 기본 정보들을 세팅했습니다.
- Swagger 문서에서 HTTP 에러코드에 대한 커스텀 어노테이션을 추가했습니다.

### 🔥 어떻게 해결했나요?
- @ApiResponse로 어노테이션을 각각 정의하고, 메서드에 적용할 수 있도록 만들었습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 어노테이션에 정의된 내용이 Swagger 문서에 잘 반영되는지 확인 부탁드립니다 ~~!

### 📚 참고 자료, 할 말
- 