### PR TITLE
[FEAT] 댓글 작성 시간대 및 타임 스탬프 언급 분석 기능 구현

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/Comment.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/Comment.java
@@ -16,7 +16,7 @@ public class Comment extends BaseEntity{
     private String videoId;
 
     @Column(name = "comment_id", nullable = false)
-    private String CommentId;
+    private String commentId;
 
     @Column(name = "comment_content", columnDefinition = "TEXT")
     private String commentContent;
@@ -35,10 +35,10 @@ public class Comment extends BaseEntity{
     private String writtenAt;
 
     @Builder
-    public Comment(String videoId, String CommentId, String commentContent,
+    public Comment(String videoId, String commentId, String commentContent,
                    Integer likeCount, Emotion emotion, String writer, String writtenAt) {
         this.videoId = videoId;
-        this.CommentId = CommentId;
+        this.commentId = commentId;
         this.commentContent = commentContent;
         this.likeCount = likeCount;
         this.emotion = emotion;

--- a/src/main/java/com/knu/sosuso/capstone/domain/Comment.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/Comment.java
@@ -15,8 +15,8 @@ public class Comment extends BaseEntity{
     @Column(name = "video_id", nullable = false)
     private String videoId;
 
-    @Column(name = "api_comment_id", nullable = false)
-    private String apiCommentId;
+    @Column(name = "comment_id", nullable = false)
+    private String CommentId;
 
     @Column(name = "comment_content", columnDefinition = "TEXT")
     private String commentContent;
@@ -35,10 +35,10 @@ public class Comment extends BaseEntity{
     private String writtenAt;
 
     @Builder
-    public Comment(String videoId, String apiCommentId, String commentContent,
+    public Comment(String videoId, String CommentId, String commentContent,
                    Integer likeCount, Emotion emotion, String writer, String writtenAt) {
         this.videoId = videoId;
-        this.apiCommentId = apiCommentId;
+        this.CommentId = CommentId;
         this.commentContent = commentContent;
         this.likeCount = likeCount;
         this.emotion = emotion;

--- a/src/main/java/com/knu/sosuso/capstone/dto/response/CommentApiResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/response/CommentApiResponse.java
@@ -1,12 +1,14 @@
 package com.knu.sosuso.capstone.dto.response;
 
 import java.util.List;
+import java.util.Map;
 
 public record CommentApiResponse(
+        Map<Integer, Integer> hourlyDistribution,   // 24시간 단위 댓글 분포 추가
         List<CommentData> allComments               // 전체 댓글
 ) {
     public record CommentData(
-            String id,
+            String id,                               // YouTube API 댓글 고유 ID
             String authorName,                       // 작성자 이름
             String commentText,                      // 댓글 본문
             int likeCount,                           // 좋아요 수

--- a/src/main/java/com/knu/sosuso/capstone/dto/response/CommentApiResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/response/CommentApiResponse.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 public record CommentApiResponse(
         Map<Integer, Integer> hourlyDistribution,   // 24시간 단위 댓글 분포 추가
+        Map<String, Integer> mentionedTimestamp, // Top 5 타임스탬프 언급
         List<CommentData> allComments               // 전체 댓글
 ) {
     public record CommentData(

--- a/src/main/java/com/knu/sosuso/capstone/dto/response/CommentApiResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/response/CommentApiResponse.java
@@ -6,6 +6,7 @@ public record CommentApiResponse(
         List<CommentData> allComments               // 전체 댓글
 ) {
     public record CommentData(
+            String id,
             String authorName,                       // 작성자 이름
             String commentText,                      // 댓글 본문
             int likeCount,                           // 좋아요 수

--- a/src/main/java/com/knu/sosuso/capstone/repository/CommentRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/repository/CommentRepository.java
@@ -13,7 +13,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByVideoIdOrderByLikeCountDesc(String videoId);
 
     // 중복 댓글 체크
-    boolean existsByApiCommentId(String apiCommentId);
+    boolean existsByCommentId(String apiCommentId);
 
     // 비디오별 댓글 삭제
     void deleteByVideoId(String videoId);

--- a/src/main/java/com/knu/sosuso/capstone/repository/CommentRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/repository/CommentRepository.java
@@ -13,7 +13,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByVideoIdOrderByLikeCountDesc(String videoId);
 
     // 중복 댓글 체크
-    boolean existsByCommentId(String apiCommentId);
+    boolean existsByCommentId(String CommentId);
 
     // 비디오별 댓글 삭제
     void deleteByVideoId(String videoId);

--- a/src/main/java/com/knu/sosuso/capstone/service/CommentService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/CommentService.java
@@ -108,7 +108,7 @@ public class CommentService {
             List<Comment> commentsToSave = comments.stream()
                     .map(commentData -> Comment.builder()
                             .videoId(videoId)
-                            .CommentId(commentData.id())
+                            .commentId(commentData.id())
                             .commentContent(commentData.commentText())
                             .likeCount(commentData.likeCount())
                             .emotion(Emotion.other) // 임시로 other 설정

--- a/src/main/java/com/knu/sosuso/capstone/service/CommentService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/CommentService.java
@@ -17,11 +17,11 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,6 +30,8 @@ public class CommentService {
     private static final Logger logger = LoggerFactory.getLogger(CommentService.class);
     private static final String YOUTUBE_COMMENT_API_URL = "https://www.googleapis.com/youtube/v3/commentThreads";
     private static final int MAX_RESULTS_PER_REQUEST = 100;
+    private static final Pattern HOUR_PATTERN = Pattern.compile("\\b(\\d{1,2}):(\\d{2}):(\\d{2})\\b");
+    private static final Pattern MINUTE_PATTERN = Pattern.compile("\\b(\\d{1,2}):(\\d{2})\\b");
 
     private final RestTemplate restTemplate;
     private final String apiKey;
@@ -55,15 +57,15 @@ public class CommentService {
             allComments.sort(Comparator.comparingInt(CommentData::likeCount).reversed());
 
             Map<Integer, Integer> hourlyDistribution = analyzeHourlyDistribution(allComments);
+            Map<String, Integer> mentionedTimestamp = analyzeMentionedTimestamp(allComments);
 
             logger.info("댓글 정보 조회 완료: videoId={}, 댓글 수={}", videoId, allComments.size());
-            return new CommentApiResponse(hourlyDistribution, allComments);
+            return new CommentApiResponse(hourlyDistribution, mentionedTimestamp, allComments);
 
         } catch (HttpClientErrorException.Forbidden e) {
             logger.warn("댓글 접근 금지: videoId={}", videoId);
             // 빈 댓글 리스트 반환 (댓글 비활성화는 정상적인 상황)
-            return new CommentApiResponse(new HashMap<>(), new ArrayList<>());
-
+            return new CommentApiResponse(new HashMap<>(), new HashMap<>(), new ArrayList<>());
         } catch (HttpClientErrorException.NotFound e) {
             logger.warn("비디오를 찾을 수 없음: videoId={}", videoId);
             throw new IllegalArgumentException("존재하지 않는 비디오입니다", e);
@@ -170,8 +172,9 @@ public class CommentService {
                 .collect(Collectors.toList());
 
         Map<Integer, Integer> hourlyDistribution = analyzeHourlyDistribution(commentDataList);
+        Map<String, Integer> mentionedTimestamp = analyzeMentionedTimestamp(commentDataList);
 
-        return new CommentApiResponse(hourlyDistribution, commentDataList);
+        return new CommentApiResponse(hourlyDistribution, mentionedTimestamp, commentDataList);
     }
 
     private List<CommentData> fetchAllComments(String videoId) {
@@ -313,6 +316,102 @@ public class CommentService {
 
         logger.info("시간대별 댓글 분포 분석 완료 (한국시간): 총 댓글 수={}", comments.size());
         return hourlyCount;
+    }
+
+    private Map<String, Integer> analyzeMentionedTimestamp(List<CommentData> comments) {
+        Map<String, Integer> timestampCount = new HashMap<>();
+
+        if (comments == null || comments.isEmpty()) {
+            return new LinkedHashMap<>();
+        }
+
+        for (CommentData comment : comments) {
+            Set<String> uniqueTimestamps = extractAllTimestamps(comment.commentText(), HOUR_PATTERN, MINUTE_PATTERN);
+
+            if (uniqueTimestamps.isEmpty()) {
+                continue;
+            }
+
+            for (String timestamp : uniqueTimestamps) {
+                timestampCount.merge(timestamp, 1, Integer::sum);
+            }
+        }
+
+        logger.info("시간대 언급 분석 완료: 총 {}개의 서로 다른 시간대가 언급됨", timestampCount.size());
+
+        // 언급 횟수 기준으로 정렬하고 Top 5개 반환
+        return timestampCount.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .limit(5)
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (e1, e2) -> e1,
+                        LinkedHashMap::new
+                ));
+    }
+
+    // 모든 타임스탬프를 위치 기반으로 추출 (중복 자동 제거)
+    private Set<String> extractAllTimestamps(String commentText, Pattern hourPattern, Pattern minutePattern) {
+        Set<String> allTimestamps = new HashSet<>();
+
+        // 빈 댓글 처리
+        if (commentText == null || commentText.trim().isEmpty()) {
+            return allTimestamps;
+        }
+
+        // 시:분:초 패턴 처리
+        List<int[]> hourRanges = new ArrayList<>();
+        Matcher hourMatcher = hourPattern.matcher(commentText);
+
+        while (hourMatcher.find()) {
+            try {
+                int hours = Integer.parseInt(hourMatcher.group(1));
+                int minutes = Integer.parseInt(hourMatcher.group(2));
+                int seconds = Integer.parseInt(hourMatcher.group(3));
+
+                // 유효성 검사 (시간은 24시간 제한 추가)
+                if (hours <= 23 && minutes <= 59 && seconds <= 59) {
+                    String timestamp = String.format("%d:%02d:%02d", hours, minutes, seconds);
+                    allTimestamps.add(timestamp);
+                    hourRanges.add(new int[]{hourMatcher.start(), hourMatcher.end()});
+                }
+            } catch (NumberFormatException e) {
+                continue;
+            }
+        }
+
+        // 분:초 패턴 처리
+        Matcher minuteMatcher = minutePattern.matcher(commentText);
+
+        while (minuteMatcher.find()) {
+            try {
+                int minutes = Integer.parseInt(minuteMatcher.group(1));
+                int seconds = Integer.parseInt(minuteMatcher.group(2));
+
+                // 유효성 검사 강화 (분도 99분 제한)
+                if (minutes <= 99 && seconds <= 59) {
+                    int start = minuteMatcher.start();
+                    int end = minuteMatcher.end();
+
+                    boolean isOverlapping = false;
+                    for (int[] range : hourRanges) {
+                        if (!(end <= range[0] || start >= range[1])) {
+                            isOverlapping = true;
+                            break;
+                        }
+                    }
+
+                    if (!isOverlapping) {
+                        allTimestamps.add(minuteMatcher.group());
+                    }
+                }
+            } catch (NumberFormatException e) {
+                continue;
+            }
+        }
+
+        return allTimestamps;
     }
 
     private boolean isValidPageToken(String pageToken) {


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #33 
---
### 🚀 어떤 기능을 구현했나요?
- YouTube API 댓글 ID를 고유 식별자로 변경했습니다.
- 댓글 작성 시간을 24시간 단위로 분류하여 Map<Integer, Integer> 형태로 생성했습니다.
- 정규식 패턴으로 댓글에서 타임스탬프를 추출했습니다. (mm:ss, hh:mm:ss 형식)
- 가장 많이 언급된 타임스탬프 TOP 5를 추출했습니다.

### 🔥 어떻게 해결했나요?
- UTC 시간을 한국 시간(KST)으로 자동 변환하여 정확한 시간대를 분석했습니다.
- 댓글당 중복 타임스탬프는 1회만 카운트 했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 시간대 변환 로직의 정확성을 확인해주세요.

### 📚 참고 자료, 할 말
- 없습니다.
