### PR TITLE
[FEATURE] 유튜브 영상 댓글에 대한 AI 분석 요청 구현

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/ai/dto/AnalysisRequest.java
+++ b/src/main/java/com/knu/sosuso/capstone/ai/dto/AnalysisRequest.java
@@ -1,0 +1,9 @@
+package com.knu.sosuso.capstone.ai.dto;
+
+import java.util.Map;
+
+public record AnalysisRequest(
+        String videoId,
+        Map<String, String> comments // Map<apiCommentId, commentContent>
+) {
+}

--- a/src/main/java/com/knu/sosuso/capstone/ai/dto/AnalysisResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/ai/dto/AnalysisResponse.java
@@ -1,0 +1,18 @@
+package com.knu.sosuso.capstone.ai.dto;
+
+import com.knu.sosuso.capstone.domain.enums.SentimentType;
+
+import java.util.List;
+import java.util.Map;
+
+public record AnalysisResponse(
+        Long videoId, // 영상 videoId
+        String apiVideoId, // 영상 apiVideoId
+        String summation, // 전체 댓글 요약
+        boolean isWarning,
+        List<String> keywords, // 댓글 주요 키워드
+        Map<String, SentimentType> sentimentComments, // 댓글별 긍정, 부정, 기타
+        Map<String, Double> languageRatio, // 언어 비율
+        Map<String, Double> sentimentRatio // 전체 댓글 긍정, 부정, 기타 비율
+) {
+}

--- a/src/main/java/com/knu/sosuso/capstone/ai/service/AnalysisService.java
+++ b/src/main/java/com/knu/sosuso/capstone/ai/service/AnalysisService.java
@@ -1,0 +1,40 @@
+package com.knu.sosuso.capstone.ai.service;
+
+import com.knu.sosuso.capstone.ai.dto.AnalysisRequest;
+import com.knu.sosuso.capstone.ai.dto.AnalysisResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@RequiredArgsConstructor
+@Service
+public class AnalysisService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String FASTAPI_URL = "https://7454-49-171-245-132.ngrok-free.app/analyze";
+
+    /**
+     * AI에 분석 요청
+     * @param analysisRequest
+     * @return
+     */
+    public AnalysisResponse requestAnalysis(AnalysisRequest analysisRequest) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<AnalysisRequest> entity = new HttpEntity<>(analysisRequest, headers);
+
+        ResponseEntity<AnalysisResponse> analysisResponse = restTemplate.postForEntity(
+                FASTAPI_URL,
+                entity,
+                AnalysisResponse.class
+        );
+
+        if (analysisResponse.getStatusCode() == HttpStatus.OK && analysisResponse.getBody() != null) {
+            return analysisResponse.getBody();
+        } else {
+            throw new RuntimeException("FastAPI request failed: " + analysisResponse.getStatusCode());
+        }
+    }
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #37 
---
### 🚀 어떤 기능을 구현했나요?
- 유튜브 댓글 데이터를 FastAPI 서버로 전달하여 분석 결과를 요청합니다.

### 🔥 어떻게 해결했나요?
- `RestTemplate`을 사용하여 `application/json` 헤더로 FastAPI의 `/analyze` 엔드포인트에 `POST` 요청을 보냅니다.
- 응답 결과를 `AnalysisResponse` 객체로 반환합니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
-

### 📚 참고 자료, 할 말
- FastAPI 고정 도메인 사용 중입니다.