### PR TITLE
[FEATURE] YouTube 댓글의 최대 개수 지정 및 서비스 코드 개선

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/service/SearchService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/SearchService.java
@@ -11,19 +11,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class SearchService {
 
-    private static final int MAX_AI_ANALYSIS_COMMENTS = 500;
-
     private final VideoService videoService;
-    private final CommentService commentService;
     private final ChannelService channelService;
-    private final AnalysisService analysisService;
+    private final VideoProcessingService videoProcessingService;
 
     // 1. 검색어 입력
     public SearchResponse search(String query) {
@@ -50,10 +45,6 @@ public class SearchService {
         }
     }
 
-    private boolean isVideoUrl(String url) {
-        return url.contains("youtube.com/watch?v=") || url.contains("youtu.be/");
-    }
-
     // 3. 영상 정보 가져옴
     private SearchUrlResponse searchVideo(String videoUrl) {
         String apiVideoId = videoService.extractVideoId(videoUrl);
@@ -64,63 +55,11 @@ public class SearchService {
 
         log.info("비디오 검색 시작: apiVideoId={}", apiVideoId);
 
-        try {
-            // 관련도순 상한선 기준 전체 댓글 가져오기
-            List<CommentApiResponse.CommentData> allComments = commentService.fetchAllComments(apiVideoId);
+        return videoProcessingService.processVideo(apiVideoId, true);
+    }
 
-            if (allComments.isEmpty()) {
-                log.info("댓글 불러오기 실패, AI 분석을 건너뜁니다: apiVideoId={}", apiVideoId);
-
-                VideoApiResponse videoApiResponse = videoService.getVideoInfo(apiVideoId, 0);
-                videoService.saveVideoInformation(videoApiResponse);
-                CommentApiResponse emptyComment = new CommentApiResponse(new HashMap<>(), new HashMap<>(), new ArrayList<>());
-                return new SearchUrlResponse(videoApiResponse, emptyComment);
-            }
-
-            // AI 분석용: 관련도순 상위 500개
-            Map<String, String> commentsForAI = new HashMap<>();
-            int commentsToAnalyze = Math.min(allComments.size(), MAX_AI_ANALYSIS_COMMENTS);
-            for (int i = 0; i < commentsToAnalyze; i++) {
-                CommentApiResponse.CommentData commentDatum = allComments.get(i);
-                commentsForAI.put(commentDatum.id(), commentDatum.commentText());
-            }
-
-            // 클라이언트용: 좋아요순 정렬
-            List<CommentApiResponse.CommentData> sortedComments = new ArrayList<>(allComments);
-            sortedComments.sort(Comparator.comparingInt(CommentApiResponse.CommentData::likeCount).reversed());
-
-            // 분석 데이터 생성
-            Map<Integer, Integer> hourlyDistribution = commentService.analyzeHourlyDistribution(sortedComments);
-            Map<String, Integer> mentionedTimestamp = commentService.analyzeMentionedTimestamp(sortedComments);
-            CommentApiResponse commentInfo = new CommentApiResponse(hourlyDistribution, mentionedTimestamp, sortedComments);
-
-            log.info("AI 분석 대상 댓글: 전체={}, 분석대상={}", allComments.size(), commentsForAI.size());
-
-            int totalCommentCount = commentInfo.allComments().size();
-            VideoApiResponse videoInfo = null;
-            try {
-                AnalysisRequest analysisRequest = new AnalysisRequest(apiVideoId, commentsForAI);
-                AnalysisResponse analysisResponse = analysisService.requestAnalysis(analysisRequest);
-                commentService.saveComments(commentInfo, analysisResponse);
-
-                videoInfo = videoService.getVideoInfo(apiVideoId, totalCommentCount);
-                videoService.saveVideoAnalysisInformation(videoInfo, analysisResponse);
-            } catch (Exception e) {
-                log.warn("AI 분석 실패, 분석 없이 진행: {}", e.getMessage());
-
-                VideoApiResponse videoApiResponse = videoService.getVideoInfo(apiVideoId, totalCommentCount);
-                videoInfo = videoService.saveVideoInformation(videoApiResponse);
-            }
-
-            log.info("비디오 검색 완료: apiVideoId={}, 댓글수={}",
-                    apiVideoId, commentInfo.allComments().size());
-
-            return new SearchUrlResponse(videoInfo, commentInfo);
-
-        } catch (Exception e) {
-            log.error("비디오 검색 실패: apiVideoId={}, error={}", apiVideoId, e.getMessage());
-            throw e;
-        }
+    private boolean isVideoUrl(String url) {
+        return url.contains("youtube.com/watch?v=") || url.contains("youtu.be/");
     }
 
     private Object searchChannels(String query) {

--- a/src/main/java/com/knu/sosuso/capstone/service/VideoProcessingService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/VideoProcessingService.java
@@ -1,0 +1,122 @@
+package com.knu.sosuso.capstone.service;
+
+import com.knu.sosuso.capstone.ai.dto.AnalysisRequest;
+import com.knu.sosuso.capstone.ai.dto.AnalysisResponse;
+import com.knu.sosuso.capstone.ai.service.AnalysisService;
+import com.knu.sosuso.capstone.dto.response.CommentApiResponse;
+import com.knu.sosuso.capstone.dto.response.SearchUrlResponse;
+import com.knu.sosuso.capstone.dto.response.VideoApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class VideoProcessingService {
+
+    private static final int MAX_AI_ANALYSIS_COMMENTS = 500;
+
+    private final VideoService videoService;
+    private final CommentService commentService;
+    private final AnalysisService analysisService;
+
+    /**
+     * 비디오 완전 처리 (댓글 수집 + AI 분석 + DB 저장)
+     * SearchService와 TrendingService에서 공통으로 사용
+     *
+     * @param apiVideoId       비디오 ID
+     * @param enableAIAnalysis AI 분석 수행 여부
+     * @return 처리된 비디오 + 댓글 정보
+     */
+    public SearchUrlResponse processVideo(String apiVideoId, boolean enableAIAnalysis) {
+        if (apiVideoId == null || apiVideoId.trim().isEmpty()) {
+            throw new IllegalArgumentException("비디오 ID는 필수입니다.");
+        }
+
+        try {
+            log.info("비디오 처리 시작: apiVideoId={}, AI분석={}", apiVideoId, enableAIAnalysis);
+
+            // 1. 댓글 정보 가져오기 (한 번의 API 호출로 원본 + 처리된 댓글 모두 획득)
+            List<CommentApiResponse.CommentData> allComments = commentService.fetchAllComments(apiVideoId);
+
+            if (allComments.isEmpty()) {
+                log.info("댓글이 없음, AI 분석 건너뛰기: apiVideoId={}", apiVideoId);
+
+                CommentApiResponse emptyResponse = new CommentApiResponse(new HashMap<>(), new HashMap<>(), new ArrayList<>());
+                VideoApiResponse videoApiResponse = videoService.getVideoInfo(apiVideoId, 0);
+                VideoApiResponse saveVideo = videoService.saveVideoInformation(videoApiResponse);
+                return new SearchUrlResponse(saveVideo, emptyResponse);
+            }
+
+            int totalCommentCount = allComments.size();
+            VideoApiResponse videoInfo;
+
+            // 2. AI 분석 (이미 가져온 댓글에서 상위 500개만 추출)
+            boolean aiAnalysisSuccess = false;
+            AnalysisResponse analysisResponse = null;
+
+            if (enableAIAnalysis) {
+                try {
+                    // AI 분석용 댓글 추출
+                    Map<String, String> commentsForAI = commentService.extractCommentsForAI(
+                            allComments, MAX_AI_ANALYSIS_COMMENTS);
+
+                    if (!commentsForAI.isEmpty()) {
+                        log.info("AI 분석 요청 시작: apiVideoId={}, 분석 댓글 수={}",
+                                apiVideoId, commentsForAI.size());
+
+                        // FastAPI 서버로 AI 분석 요청
+                        AnalysisRequest analysisRequest = new AnalysisRequest(apiVideoId, commentsForAI);
+                        analysisResponse = analysisService.requestAnalysis(analysisRequest);
+                        aiAnalysisSuccess = true;
+
+                        log.info("AI 분석 성공: apiVideoId={}, 요약 길이={}, 경고={}",
+                                apiVideoId, analysisResponse.summation().length(), analysisResponse.isWarning());
+                    }
+                } catch (org.springframework.web.client.ResourceAccessException e) {
+                    log.error("AI 서버 연결 실패 (네트워크): apiVideoId={}, error={}", apiVideoId, e.getMessage());
+                } catch (org.springframework.web.client.HttpClientErrorException e) {
+                    log.error("AI 서버 클라이언트 오류: apiVideoId={}, status={}", apiVideoId, e.getStatusCode());
+                } catch (org.springframework.web.client.HttpServerErrorException e) {
+                    log.error("AI 서버 내부 오류: apiVideoId={}, status={}", apiVideoId, e.getStatusCode());
+                } catch (RuntimeException e) {
+                    log.error("AI 분석 실패: apiVideoId={}, error={}", apiVideoId, e.getMessage());
+                } catch (Exception e) {
+                    log.error("AI 분석 예상치 못한 오류: apiVideoId={}, error={}", apiVideoId, e.getMessage());
+                }
+            } else {
+                log.info("AI 분석 비활성화: apiVideoId={}", apiVideoId);
+            }
+
+            // 3. 클라이언트용 응답 생성
+            CommentApiResponse commentInfo = commentService.processCommentsForClient(allComments);
+
+            // 4. 비디오 정보 조회 및 저장
+            videoInfo = videoService.getVideoInfo(apiVideoId, totalCommentCount);
+
+            if (aiAnalysisSuccess && analysisResponse != null) {
+                // AI 분석 성공: 결과와 함께 저장
+                commentService.saveComments(commentInfo, analysisResponse);  // 댓글 + 감정
+                videoInfo = videoService.saveVideoAnalysisInformation(videoInfo, analysisResponse);
+                log.info("비디오 저장 완료 (AI 분석 포함): apiVideoId={}", apiVideoId);
+            } else {
+                // AI 분석 실패 또는 비활성화: 기본 저장
+                videoInfo = videoService.saveVideoInformation(videoInfo);
+                log.info("비디오 저장 완료 (AI 분석 미포함): apiVideoId={}", apiVideoId);
+            }
+
+            log.info("비디오 처리 완료: apiVideoId={}, 댓글수={}", apiVideoId, totalCommentCount);
+            return new SearchUrlResponse(videoInfo, commentInfo);
+
+        } catch (Exception e) {
+            log.error("비디오 처리 실패: apiVideoId={}, error={}", apiVideoId, e.getMessage());
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #52 
---
### 🚀 어떤 기능을 구현했나요?
- 전체 댓글의 개수와 AI 분석에 필요한 댓글의 최대 개수를 지정합니다.
- SearchService의 중복 호출을 제거합니다.
- 서비스 간 결합도가 높은 점을 개선합니다.

### 🔥 어떻게 해결했나요?
- MAX_TOTAL_COMMENTS와 MAX_AI_ANALYSIS_COMMENTS로 최대 댓글 개수를 상수로 지정해뒀습니다.
- VideoProcessingService를 생성하여 각 서비스의 결합도를 낮추었습니다.
- fetchAllComments(): YouTube API 담당
- extractCommentsForAI(): AI용 데이터 추출
- processCommentsForClient(): 클라이언트용 데이터 가공

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 구조적으로 대거 수정을 했는데 이상 없는지 테스트 부탁드립니다.

### 📚 참고 자료, 할 말
- SearchService와 TrendingService의 중복 호출 문제를 해결하고, 깔끔한 의존성 구조로 개선했습니다.
- 바로 이어서 비디오 테이블에 hourlyDistribution와 mentionedTimestamp 필드를 추가로 저장하는  작업 진행하겠습니다.
