### PR TITLE
[FEATURE] Video 테이블에 필드 추가 및 저장 로직 개선

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/Video.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/Video.java
@@ -43,6 +43,12 @@ public class Video extends BaseEntity {
     @Column(name = "subscriber_count")
     private String subscriberCount;
 
+    @Column(name = "hourly_distribution", columnDefinition = "JSON")
+    private String hourlyDistribution;
+
+    @Column(name = "mentioned_timestamp", columnDefinition = "JSON")
+    private String mentionedTimestamp;
+
     @Column(name = "summation")
     private String summation;
 
@@ -61,7 +67,9 @@ public class Video extends BaseEntity {
     private String uploadedAt;
 
     @Builder
-    public Video(String apiVideoId, String title, String description, String viewCount, String likeCount, String commentCount, String thumbnailUrl, String channelId, String channelName, String subscriberCount, String summation, boolean isWarning, String uploadedAt) {
+    public Video(String apiVideoId, String title, String description, String viewCount, String likeCount, String commentCount, String thumbnailUrl, String channelId, String channelName, String subscriberCount, String hourlyDistribution,
+                 String mentionedTimestamp, String summation,
+                 boolean isWarning, String uploadedAt) {
         this.apiVideoId = apiVideoId;
         this.title = title;
         this.description = description;
@@ -72,6 +80,8 @@ public class Video extends BaseEntity {
         this.channelId = channelId;
         this.channelName = channelName;
         this.subscriberCount = subscriberCount;
+        this.hourlyDistribution = hourlyDistribution;
+        this.mentionedTimestamp = mentionedTimestamp;
         this.summation = summation;
         this.isWarning = isWarning;
         this.uploadedAt = uploadedAt;


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #56 
---
### 🚀 어떤 기능을 구현했나요?
- 백엔드에서 자체 분석하는 댓글 시간대별 분포(hourlyDistribution)와 타임스탬프(mentionedTimestamp)를 Video 테이블에 저장합니다.
- VideoService의 저장 메소드를 오버로딩으로 통일하여 일관성 있는 API 설계를 완성합니다.

### 🔥 어떻게 해결했나요?
- Video 엔티티에 hourlyDistribution, mentionedTimestamp 필드 추가
- VideoService에 saveVideoInformation() 3가지 오버로딩 구현
- 케이스: 댓글 없음 / 댓글 있음, AI 분석 실패 / 댓글 있음, AI 분석 성공

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 각 케이스에 대해 DB 저장이 잘 이루어지는지 확인해주세요.

### 📚 참고 자료, 할 말
- 없습니다.
