### PR TITLE
[FEATURE] 구글 소셜 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/controller/AuthController.java
+++ b/src/main/java/com/knu/sosuso/capstone/controller/AuthController.java
@@ -2,13 +2,14 @@ package com.knu.sosuso.capstone.controller;
 
 import com.knu.sosuso.capstone.dto.ResponseDto;
 import com.knu.sosuso.capstone.dto.response.LoginResponse;
+import com.knu.sosuso.capstone.security.CustomSuccessHandler;
 import com.knu.sosuso.capstone.service.AuthService;
 import com.knu.sosuso.capstone.swagger.AuthControllerSwagger;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController implements AuthControllerSwagger {
 
     private final AuthService authService;
+    private final CustomSuccessHandler customSuccessHandler;
 
     @GetMapping("/login")
     public ResponseDto<LoginResponse> googleLogin(
@@ -23,5 +25,14 @@ public class AuthController implements AuthControllerSwagger {
     ) {
         LoginResponse loginResponse = authService.getUserInformation(token);
         return ResponseDto.of(loginResponse, "Successfully signed in to Google Social.");
+    }
+
+    @PostMapping("/logout")
+    public ResponseDto<?> googleLogout(
+            @CookieValue(value = "Authorization", required = false) String token,
+            HttpServletResponse response
+    ) throws IOException {
+        customSuccessHandler.logout(token, response);
+        return ResponseDto.of("Successfully Logged out.");
     }
 }

--- a/src/main/java/com/knu/sosuso/capstone/service/AuthService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/AuthService.java
@@ -36,11 +36,4 @@ public class AuthService {
                 user.getPicture()
         );
     }
-    
-    public boolean isTokenValid(String token) {
-        if (token == null || token.trim().isEmpty()) {
-            return false;
-        }
-        return jwtUtil.isValidToken(token);
-    }
 }

--- a/src/main/java/com/knu/sosuso/capstone/swagger/AuthControllerSwagger.java
+++ b/src/main/java/com/knu/sosuso/capstone/swagger/AuthControllerSwagger.java
@@ -9,7 +9,10 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.CookieValue;
+
+import java.io.IOException;
 
 @Tag(name = "구글 소셜 로그인 API")
 public interface AuthControllerSwagger {
@@ -29,4 +32,20 @@ public interface AuthControllerSwagger {
     ResponseDto<LoginResponse> googleLogin(
             @CookieValue("Authorization") String token
     );
+
+    @Operation(
+            summary = "구글 소셜 로그아웃",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "구글 소셜 로그아웃 성공"
+                    )
+            }
+    )
+    @ErrorCode400
+    @ErrorCode500
+    ResponseDto<?> googleLogout(
+            @CookieValue(value = "Authorization", required = false) String token,
+            HttpServletResponse response
+    ) throws IOException;
 }


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #73
---
### 🚀 어떤 기능을 구현했나요?
- 구글 소셜 로그아웃 기능을 구현했습니다. 

### 🔥 어떻게 해결했나요?
- 로그아웃 요청 시, 구글 로그아웃 URL(`https://accounts.google.com/logout`)로 리다이렉트 됩니다.
- JWT 쿠키를 삭제합니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
-

### 📚 참고 자료, 할 말
- 프론트 로컬 스토리지에 저장되어 있는 유저 정보 초기화가 필요합니다.