### PR TITLE
[FEATURE] 관심 채널 등록 취소 기능 구현

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/controller/FavoriteChannelController.java
+++ b/src/main/java/com/knu/sosuso/capstone/controller/FavoriteChannelController.java
@@ -2,6 +2,7 @@ package com.knu.sosuso.capstone.controller;
 
 import com.knu.sosuso.capstone.dto.ResponseDto;
 import com.knu.sosuso.capstone.dto.request.RegisterFavoriteChannelRequest;
+import com.knu.sosuso.capstone.dto.response.favorite_channel.CancelFavoriteChannelResponse;
 import com.knu.sosuso.capstone.dto.response.favorite_channel.RegisterFavoriteChannelResponse;
 import com.knu.sosuso.capstone.service.FavoriteChannelService;
 import com.knu.sosuso.capstone.swagger.FavoriteChannelControllerSwagger;
@@ -23,5 +24,14 @@ public class FavoriteChannelController implements FavoriteChannelControllerSwagg
             ) {
         RegisterFavoriteChannelResponse registerFavoriteChannelResponse = favoriteChannelService.registerFavoriteChannel(token, registerFavoriteChannelRequest);
         return ResponseDto.of(registerFavoriteChannelResponse, "Successfully registered the favorite channel.");
+    }
+
+    @DeleteMapping("{id}")
+    public ResponseDto<CancelFavoriteChannelResponse> cancelFavoriteChannel(
+            @CookieValue("Authorization") String token,
+            @PathVariable("id") Long channelId
+    ) {
+        CancelFavoriteChannelResponse cancelFavoriteChannelResponse = favoriteChannelService.cancelFavoriteChannel(token, channelId);
+        return ResponseDto.of(cancelFavoriteChannelResponse, "successfully canceled the favorite channel.");
     }
 }

--- a/src/main/java/com/knu/sosuso/capstone/dto/response/favorite_channel/CancelFavoriteChannelResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/response/favorite_channel/CancelFavoriteChannelResponse.java
@@ -1,0 +1,6 @@
+package com.knu.sosuso.capstone.dto.response.favorite_channel;
+
+public record CancelFavoriteChannelResponse(
+        Long favoriteChannelId
+) {
+}

--- a/src/main/java/com/knu/sosuso/capstone/service/FavoriteChannelService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/FavoriteChannelService.java
@@ -3,6 +3,7 @@ package com.knu.sosuso.capstone.service;
 import com.knu.sosuso.capstone.domain.FavoriteChannel;
 import com.knu.sosuso.capstone.domain.User;
 import com.knu.sosuso.capstone.dto.request.RegisterFavoriteChannelRequest;
+import com.knu.sosuso.capstone.dto.response.favorite_channel.CancelFavoriteChannelResponse;
 import com.knu.sosuso.capstone.dto.response.favorite_channel.RegisterFavoriteChannelResponse;
 import com.knu.sosuso.capstone.repository.FavoriteChannelRepository;
 import com.knu.sosuso.capstone.repository.UserRepository;
@@ -45,5 +46,26 @@ public class FavoriteChannelService {
 
         favoriteChannelRepository.save(favoriteChannel);
         return new RegisterFavoriteChannelResponse(apiChannelId);
+    }
+
+    // Todo custom exception으로 바꾸기
+    @Transactional
+    public CancelFavoriteChannelResponse cancelFavoriteChannel(String token, Long favoriteChannelId) {
+        if (!jwtUtil.isValidToken(token)) {
+            throw new RuntimeException("유효하지 않은 토큰입니다.");
+        }
+
+        Long userId = jwtUtil.getUserId(token);
+
+        FavoriteChannel favoriteChannel = favoriteChannelRepository.findById(favoriteChannelId)
+                .orElseThrow(() -> new RuntimeException("관심 채널로 등록되어 있지 않은 채널입니다."));
+
+        if (!favoriteChannel.getUser().getId().equals(userId)) {
+            throw new RuntimeException("본인의 관심 채널만 취소할 수 있습니다.");
+        }
+
+        favoriteChannelRepository.deleteById(favoriteChannelId);
+
+        return new CancelFavoriteChannelResponse(favoriteChannelId);
     }
 }

--- a/src/main/java/com/knu/sosuso/capstone/swagger/FavoriteChannelControllerSwagger.java
+++ b/src/main/java/com/knu/sosuso/capstone/swagger/FavoriteChannelControllerSwagger.java
@@ -2,15 +2,18 @@ package com.knu.sosuso.capstone.swagger;
 
 import com.knu.sosuso.capstone.dto.ResponseDto;
 import com.knu.sosuso.capstone.dto.request.RegisterFavoriteChannelRequest;
+import com.knu.sosuso.capstone.dto.response.favorite_channel.CancelFavoriteChannelResponse;
 import com.knu.sosuso.capstone.dto.response.favorite_channel.RegisterFavoriteChannelResponse;
 import com.knu.sosuso.capstone.swagger.annotation.ErrorCode400;
 import com.knu.sosuso.capstone.swagger.annotation.ErrorCode500;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "관심 채널 API")
@@ -31,5 +34,22 @@ public interface FavoriteChannelControllerSwagger {
     ResponseDto<RegisterFavoriteChannelResponse> registerFavoriteChannel(
             @CookieValue("Authorization") String token,
             @RequestBody RegisterFavoriteChannelRequest registerFavoriteChannelRequest
+    );
+
+    @Operation(
+            summary = "관심 채널 등록 취소",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "관심 채널 등록 취소 성공"
+                    )
+            }
+    )
+    @Parameter(name = "id", description = "channelId", required = true)
+    @ErrorCode400
+    @ErrorCode500
+    ResponseDto<CancelFavoriteChannelResponse> cancelFavoriteChannel(
+            @CookieValue("Authorization") String token,
+            @PathVariable("id") Long channelId
     );
 }


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #81
---
### 🚀 어떤 기능을 구현했나요?
- 관심 채널 등록 취소 기능을 구현했습니다.

### 🔥 어떻게 해결했나요?
- 토큰 검증 후, 관심 채널 등록 취소 요청이 들어온 관심 채널 데이터가 실제로 존재하는지 확인합니다.
- 이후, 요청을 보낸 사용자와 해당 관심 채널을 등록한 소유자가 일치하는지 검증합니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 
