### PR TITLE
[FEATURE] 메인 페이지 응답 기능 구현

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/controller/FavoriteChannelController.java
+++ b/src/main/java/com/knu/sosuso/capstone/controller/FavoriteChannelController.java
@@ -2,6 +2,7 @@ package com.knu.sosuso.capstone.controller;
 
 import com.knu.sosuso.capstone.dto.ResponseDto;
 import com.knu.sosuso.capstone.dto.request.RegisterFavoriteChannelRequest;
+import com.knu.sosuso.capstone.dto.response.VideoSummaryResponse;
 import com.knu.sosuso.capstone.dto.response.favorite_channel.CancelFavoriteChannelResponse;
 import com.knu.sosuso.capstone.dto.response.favorite_channel.FavoriteChannelListResponse;
 import com.knu.sosuso.capstone.dto.response.favorite_channel.RegisterFavoriteChannelResponse;
@@ -37,12 +38,22 @@ public class FavoriteChannelController implements FavoriteChannelControllerSwagg
         return ResponseDto.of(favoriteChannelListResponses, "successfully retrieved your list of favorite channels.");
     }
 
-    @DeleteMapping("{id}")
+    @DeleteMapping("{channelId}")
     public ResponseDto<CancelFavoriteChannelResponse> cancelFavoriteChannel(
             @CookieValue("Authorization") String token,
-            @PathVariable("id") Long channelId
+            @PathVariable("channelId") Long channelId
     ) {
         CancelFavoriteChannelResponse cancelFavoriteChannelResponse = favoriteChannelService.cancelFavoriteChannel(token, channelId);
         return ResponseDto.of(cancelFavoriteChannelResponse, "successfully canceled the favorite channel.");
     }
+
+    @GetMapping("{apiChannelId}")
+    public ResponseDto<VideoSummaryResponse> favoriteChannelVideo(
+            @CookieValue("Authorization") String token,
+            @PathVariable("apiChannelId") String apiChannelId
+    ){
+        VideoSummaryResponse favoriteChannelSummaryResponse = favoriteChannelService.processLatestVideoFromFavoriteChannel(token, apiChannelId);
+        return ResponseDto.of(favoriteChannelSummaryResponse, "successfully summary analysis video favorite channel.");
+    }
+
 }

--- a/src/main/java/com/knu/sosuso/capstone/controller/MainPageController.java
+++ b/src/main/java/com/knu/sosuso/capstone/controller/MainPageController.java
@@ -1,0 +1,43 @@
+package com.knu.sosuso.capstone.controller;
+
+import com.knu.sosuso.capstone.dto.ResponseDto;
+import com.knu.sosuso.capstone.dto.response.MainPageResponse;
+import com.knu.sosuso.capstone.service.FavoriteChannelService;
+import com.knu.sosuso.capstone.service.MainPageService;
+import com.knu.sosuso.capstone.service.ScrapService;
+import com.knu.sosuso.capstone.service.TrendingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/main")
+public class MainPageController {
+
+    private final MainPageService mainPageService;
+
+    @GetMapping()
+    public ResponseEntity<ResponseDto<MainPageResponse>> getMainPageData(
+            @CookieValue(value = "Authorization", required = false) String token) {
+
+        log.info("메인 페이지 데이터 조회 요청 수신");
+
+        try {
+            MainPageResponse response = mainPageService.getMainPageData(token);
+
+            log.info("메인 페이지 데이터 조회 성공");
+            return ResponseEntity.ok(ResponseDto.of(response, "메인 페이지 조회 완료"));
+
+        } catch (Exception e) {
+            log.error("메인 페이지 데이터 조회 실패: {}", e.getMessage(), e);
+            throw e;
+        }
+    }
+
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/Comment.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/Comment.java
@@ -28,7 +28,7 @@ public class Comment extends BaseEntity{
     private Integer likeCount;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "sentiment_type")
+    @Column(name = "sentiment_type", length = 255)
     private SentimentType sentimentType;
 
     @Column(name = "writer")

--- a/src/main/java/com/knu/sosuso/capstone/dto/response/MainPageResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/dto/response/MainPageResponse.java
@@ -1,0 +1,19 @@
+package com.knu.sosuso.capstone.dto.response;
+
+import com.knu.sosuso.capstone.dto.response.detail.DetailCommentDto;
+import com.knu.sosuso.capstone.dto.response.favorite_channel.FavoriteChannelListResponse;
+
+import java.util.List;
+
+public record MainPageResponse(
+        FavoriteChannelResponse favoriteChannelVideo,
+        List<VideoSummaryResponse> trendingVideos,
+        List<VideoSummaryResponse> scrapVideos
+) {
+
+    public record FavoriteChannelResponse(
+            List<FavoriteChannelListResponse> favoriteChannelList,
+            VideoSummaryResponse videoSummary,
+            List<DetailCommentDto> topComments
+    ) {}
+}

--- a/src/main/java/com/knu/sosuso/capstone/repository/CommentRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/repository/CommentRepository.java
@@ -36,5 +36,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // 감정별 조회
     List<Comment> findByVideoIdAndSentimentTypeOrderById(Long videoId, SentimentType sentimentType);
+
+    List<Comment> findByVideoIdOrderByLikeCountDesc(Long video_id);
+
 }
 

--- a/src/main/java/com/knu/sosuso/capstone/repository/FavoriteChannelRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/repository/FavoriteChannelRepository.java
@@ -10,4 +10,5 @@ public interface FavoriteChannelRepository extends JpaRepository<FavoriteChannel
     boolean existsByUserIdAndApiChannelId(Long userId, String apiChannelId);
     Optional<FavoriteChannel> findByUserIdAndApiChannelId(Long userId, String apiChannelId);
     List<FavoriteChannel> findByUserId(Long userId);
+    Optional<FavoriteChannel> findByIdAndUserId(Long favoriteChannelId, Long userId);
 }

--- a/src/main/java/com/knu/sosuso/capstone/service/ChannelService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/ChannelService.java
@@ -124,6 +124,40 @@ public class ChannelService {
         return restTemplate.getForObject(apiUrl, String.class);
     }
 
+
+    // 채널 api id로 해당 채널의 최근 영상 apiVideoId 조회
+    public String getlatestApiVideoId(String apiChannelId){
+        String apiUrl = UriComponentsBuilder.fromUriString(YOUTUBE_SEARCH_API_URL)
+                .queryParam("part", "snippet")
+                .queryParam("channelId", apiChannelId)
+                .queryParam("order", "date")
+                .queryParam("maxResults", 1)
+                .queryParam("type","video")
+                .queryParam("key", config.getKey())
+                .toUriString();
+
+        String response = restTemplate.getForObject(apiUrl, String.class);
+
+
+        return extractVideoIdFromSearchResponse(response);
+    }
+
+    private String extractVideoIdFromSearchResponse(String json){
+        try{
+            JsonNode root = objectMapper.readTree(json);
+            JsonNode items = root.path("items");
+
+            if(items.isArray() && !items.isEmpty()){
+                JsonNode videoIdNode = items.get(0).path("id").path("videoId");
+                return videoIdNode.asText();
+            }
+        }catch (Exception e){
+            log.error("관심 채널 최근 영상 응답 파싱 실패: {}", e.getMessage(), e);
+            return null;
+        }
+        return null;
+    }
+
     private List<ChannelSearchResponse.ChannelDto> parseChannelsResponse(String token, String channelsResponse) {
         try {
             JsonNode channelsRootNode = objectMapper.readTree(channelsResponse);

--- a/src/main/java/com/knu/sosuso/capstone/service/MainPageService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/MainPageService.java
@@ -1,0 +1,202 @@
+package com.knu.sosuso.capstone.service;
+
+import com.knu.sosuso.capstone.domain.Comment;
+import com.knu.sosuso.capstone.domain.FavoriteChannel;
+import com.knu.sosuso.capstone.dto.response.MainPageResponse;
+import com.knu.sosuso.capstone.dto.response.VideoSummaryResponse;
+import com.knu.sosuso.capstone.dto.response.detail.DetailCommentDto;
+import com.knu.sosuso.capstone.dto.response.favorite_channel.FavoriteChannelListResponse;
+import com.knu.sosuso.capstone.exception.BusinessException;
+import com.knu.sosuso.capstone.exception.error.AuthenticationError;
+import com.knu.sosuso.capstone.repository.FavoriteChannelRepository;
+import com.knu.sosuso.capstone.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MainPageService {
+
+    private final FavoriteChannelService favoriteChannelService;
+    private final TrendingService trendingService;
+    private final ScrapService scrapService;
+    private final ResponseMappingService responseMappingService;
+    private final FavoriteChannelRepository favoriteChannelRepository;
+    private final JwtUtil jwtUtil;
+
+    public MainPageResponse getMainPageData(String token) {
+        log.info("메인 페이지 데이터 조회 시작");
+
+        try {
+            // 1. 토큰 검증
+            if (token == null || !jwtUtil.isValidToken(token)) {
+                throw new BusinessException(AuthenticationError.INVALID_TOKEN);
+            }
+
+            // 2. 각 섹션 데이터 조회 (병렬로 처리 가능하지만 순차적으로 처리)
+            List<VideoSummaryResponse> scrapVideos = getScrapVideos(token);
+            List<VideoSummaryResponse> trendingVideos = getTrendingVideos(token);
+            MainPageResponse.FavoriteChannelResponse favoriteChannelResponse = getFavoriteChannelResponse(token);
+
+            MainPageResponse response = new MainPageResponse(
+                    favoriteChannelResponse,
+                    trendingVideos,
+                    scrapVideos
+            );
+
+            log.info("메인 페이지 데이터 조회 완료: 스크랩={}, 트렌딩={}, 즐겨찾기 채널 수={}",
+                    scrapVideos.size(),
+                    trendingVideos.size(),
+                    favoriteChannelResponse.favoriteChannelList() != null
+                            ? favoriteChannelResponse.favoriteChannelList().size() : 0);
+
+            return response;
+
+        } catch (BusinessException e) {
+            log.error("메인 페이지 데이터 조회 비즈니스 오류: {}", e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            log.error("메인 페이지 데이터 조회 실패: {}", e.getMessage(), e);
+            throw new RuntimeException("메인 페이지 데이터 조회 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 스크랩된 비디오 목록 조회 (최대 3개)
+     */
+    private List<VideoSummaryResponse> getScrapVideos(String token) {
+        try {
+            List<VideoSummaryResponse> allScrapVideos = scrapService.getScrappedVideos(token);
+
+            // 최대 3개까지만 반환
+            int maxSize = Math.min(allScrapVideos.size(), 3);
+            List<VideoSummaryResponse> limitedScrapVideos = allScrapVideos.subList(0, maxSize);
+
+            log.debug("스크랩 비디오 조회 완료: 전체={}, 반환={}", allScrapVideos.size(), limitedScrapVideos.size());
+            return limitedScrapVideos;
+
+        } catch (Exception e) {
+            log.error("스크랩 비디오 조회 실패: {}", e.getMessage(), e);
+            return new ArrayList<>(); // 실패해도 빈 리스트 반환하여 다른 섹션에 영향주지 않음
+        }
+    }
+
+    /**
+     * 트렌딩 비디오 목록 조회 (최대 3개)
+     */
+    private List<VideoSummaryResponse> getTrendingVideos(String token) {
+        try {
+            List<VideoSummaryResponse> trendingVideos = trendingService.getTrendingVideoWithComments(token, "latest", 3);
+            log.debug("트렌딩 비디오 조회 완료: 개수={}", trendingVideos.size());
+            return trendingVideos;
+
+        } catch (Exception e) {
+            log.error("트렌딩 비디오 조회 실패: {}", e.getMessage(), e);
+            return new ArrayList<>(); // 실패해도 빈 리스트 반환
+        }
+    }
+
+    /**
+     * 즐겨찾기 채널 응답 생성
+     */
+    private MainPageResponse.FavoriteChannelResponse getFavoriteChannelResponse(String token) {
+        if (!jwtUtil.isValidToken(token)) {
+            throw new BusinessException(AuthenticationError.INVALID_TOKEN);
+        }
+
+        Long userId = jwtUtil.getUserId(token);
+
+        // 즐겨찾기 채널 목록 조회
+        List<FavoriteChannelListResponse> favoriteChannelList = favoriteChannelService.getFavoriteChannelList(token);
+
+        if (favoriteChannelList.isEmpty()) {
+            log.info("즐겨찾기 채널이 없습니다");
+            return new MainPageResponse.FavoriteChannelResponse(
+                    new ArrayList<>(),
+                    null,
+                    new ArrayList<>()
+            );
+        }
+
+        FavoriteChannelListResponse selectedChannel = favoriteChannelList.get(0);
+        log.debug("선택된 채널: {}", selectedChannel.apiChannelName());
+
+        long favoriteChannelId = selectedChannel.favoriteChannelId();
+
+        Optional<FavoriteChannel> favoriteChannelOpt = favoriteChannelRepository.findByIdAndUserId(favoriteChannelId, userId);
+
+        try {
+            if (favoriteChannelOpt.isPresent()) {
+                String apiChannelId = favoriteChannelOpt.get().getApiChannelId();
+
+                // 해당 채널의 최신 비디오 하나와 댓글 조회
+                VideoSummaryResponse channelVideo;
+                List<DetailCommentDto> topComments = new ArrayList<>();
+
+                // 채널의 최신 비디오를 가져오는 로직
+                channelVideo = favoriteChannelService.processLatestVideoFromFavoriteChannel(token, apiChannelId);
+
+                if (channelVideo != null) {
+                    topComments = getTopCommentsForVideo(channelVideo.video().id());
+                }
+
+                return new MainPageResponse.FavoriteChannelResponse(
+                        favoriteChannelList,
+                        channelVideo,
+                        topComments
+                );
+            }
+        } catch (Exception e) {
+            log.error("즐겨찾기 채널 응답 생성 실패: {}", e.getMessage(), e);
+            return new MainPageResponse.FavoriteChannelResponse(
+                    new ArrayList<>(),
+                    null,
+                    new ArrayList<>()
+            );
+        }
+        return null;
+    }
+
+    /**
+     * 비디오의 상위 댓글 조회 (최대 5개)
+     */
+    private List<DetailCommentDto> getTopCommentsForVideo(String videoId) {
+        try {
+            log.debug("비디오 상위 댓글 조회 시작: videoId={}", videoId);
+
+            // DB에서 해당 비디오의 댓글 조회 (좋아요 순으로 정렬)
+            List<Comment> comments = responseMappingService.mapToTopCommentsFromDb(videoId);
+
+            if (comments.isEmpty()) {
+                log.debug("해당 비디오에 댓글이 없습니다: videoId={}", videoId);
+                return new ArrayList<>();
+            }
+
+            // Comment 엔티티를 DetailCommentDto로 변환
+            List<DetailCommentDto> topComments = comments.stream()
+                    .map(comment -> new DetailCommentDto(
+                            comment.getApiCommentId(),
+                            comment.getWriter(),
+                            comment.getCommentContent(),
+                            comment.getLikeCount(),
+                            comment.getSentimentType() != null ? comment.getSentimentType().name().toLowerCase() : null,
+                            comment.getWrittenAt()
+                    ))
+                    .collect(Collectors.toList());
+
+            log.debug("상위 댓글 조회 완료: videoId={}, 댓글 수={}", videoId, topComments.size());
+            return topComments;
+
+        } catch (Exception e) {
+            log.error("상위 댓글 조회 실패: videoId={}, error={}", videoId, e.getMessage(), e);
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/service/ResponseMappingService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/ResponseMappingService.java
@@ -3,11 +3,13 @@ package com.knu.sosuso.capstone.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.knu.sosuso.capstone.ai.dto.AIAnalysisResponse;
+import com.knu.sosuso.capstone.domain.Comment;
 import com.knu.sosuso.capstone.domain.Video;
 import com.knu.sosuso.capstone.dto.response.CommentApiResponse;
 import com.knu.sosuso.capstone.dto.response.VideoApiResponse;
 import com.knu.sosuso.capstone.dto.response.detail.*;
 import com.knu.sosuso.capstone.repository.CommentRepository;
+import com.knu.sosuso.capstone.repository.VideoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -24,6 +27,7 @@ public class ResponseMappingService {
 
     private final ObjectMapper objectMapper;
     private final CommentRepository commentRepository;
+    private final VideoRepository videoRepository;
     private final UserDataService userDataService;
 
     /**
@@ -331,6 +335,25 @@ public class ResponseMappingService {
                     }
                 })
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * DB에서 좋아요 TOP 5 댓글 추출 (public 메서드로 추가)
+     */
+    public List<Comment> mapToTopCommentsFromDb(String apiVideoId) {
+
+        Optional<Video> videoOpt  = videoRepository.findByApiVideoId(apiVideoId);
+
+        if (videoOpt.isPresent()) {
+            Long videoId = videoOpt.get().getId();
+
+            return commentRepository
+                    .findByVideoIdOrderByLikeCountDesc(videoId)
+                    .stream()
+                    .limit(5)
+                    .collect(Collectors.toList());
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/knu/sosuso/capstone/service/TrendingService.java
+++ b/src/main/java/com/knu/sosuso/capstone/service/TrendingService.java
@@ -73,7 +73,7 @@ public class TrendingService {
     /**
      * DetailPageResponse를 VideoSummaryResponse로 변환 (전체 처리 완료 후)
      */
-    private VideoSummaryResponse convertToVideoSummaryResponse(DetailPageResponse detailResponse) {
+    public VideoSummaryResponse convertToVideoSummaryResponse(DetailPageResponse detailResponse) {
         try {
             var video = detailResponse.video();
             var channel = detailResponse.channel();


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #87
---
### 🚀 어떤 기능을 구현했나요?
- 메인 페이지(관심 채널 정보 / 인기 급상승 요약 리스트 / 스크랩 요약 리스트)를 한 번에 응답하는 기능을 구현하였습니다.
- 관심 채널 중 db 저장 순으로 1개의 채널을 뽑고 해당 채널의 최신 영상 정보를 응답하는 기능을 구현하여 메인 페이지의 일부에 포함 시켰습니다.

### 🔥 어떻게 해결했나요?
- 메인 서비스를 만들어서 통합하였습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 현재 api가 모두 작동하는 상태기 때문에 예린님이 api 별로 테스트 해주시면 감사하겠습니다.
- 관심 채널 영상 조회는 메인 페이지 api에서 처리되어 필요 없을 것 같습니다. 확인해주세요.

### 📚 참고 자료, 할 말
- 현재 코드랑 예전에 적어 놓은 스웨거랑 내용이 꽤 다릅니다. 내일 수정하겠습니다.
- 기능 개발을 중점적으로 하여 구조 정리가 안 된 상태입니다.
