### PR TITLE
[REFACTOR] Progressive Loading 구현을 위한 메인/상세 페이지 API 분리

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/controller/VideoDetailController.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/controller/VideoDetailController.java
@@ -3,6 +3,7 @@ package com.knu.sosuso.capstone.domain.detail.controller;
 import com.knu.sosuso.capstone.domain.detail.dto.*;
 import com.knu.sosuso.capstone.domain.detail.service.VideoDetailService;
 import com.knu.sosuso.capstone.global.ResponseDto;
+import com.knu.sosuso.capstone.global.swagger.VideoDetailControllerSwagger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/api/videos")
-public class VideoDetailController {
+public class VideoDetailController implements VideoDetailControllerSwagger {
 
     private final VideoDetailService videoDetailService;
 

--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/controller/VideoDetailController.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/controller/VideoDetailController.java
@@ -1,12 +1,14 @@
 package com.knu.sosuso.capstone.domain.detail.controller;
 
+import com.knu.sosuso.capstone.domain.detail.dto.*;
+import com.knu.sosuso.capstone.domain.detail.service.VideoDetailService;
 import com.knu.sosuso.capstone.global.ResponseDto;
-import com.knu.sosuso.capstone.domain.detail.dto.DetailPageResponse;
-import com.knu.sosuso.capstone.domain.video.service.VideoProcessingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,19 +16,138 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/videos")
 public class VideoDetailController {
 
-    private final VideoProcessingService videoProcessingService;
+    private final VideoDetailService videoDetailService;
 
+    /**
+     * 영상 기본 정보 조회
+     * - 영상 정보 (제목, 썸네일, 조회수 등)
+     * - 채널 정보 (채널명, 구독자 수 등)
+     */
+    @GetMapping("/{apiVideoId}/basic")
+    public ResponseEntity<ResponseDto<VideoBasicResponse>> getVideoBasic(
+            @CookieValue(value = "Authorization", required = false) String token,
+            @PathVariable String apiVideoId) {
+        try {
+            log.info("영상 기본 정보 조회 요청: apiVideoId={}", apiVideoId);
+
+            VideoBasicResponse result = videoDetailService.getVideoBasic(token, apiVideoId);
+
+            log.info("영상 기본 정보 조회 완료: apiVideoId={}", apiVideoId);
+            return ResponseEntity.ok(ResponseDto.of(result, "영상 기본 정보 조회 성공"));
+
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 요청: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(ResponseDto.of(e.getMessage()));
+
+        } catch (Exception e) {
+            log.error("영상 기본 정보 조회 실패: apiVideoId={}, error={}", apiVideoId, e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(ResponseDto.of("영상 기본 정보 조회 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * 영상 분석 정보 조회 (백엔드 분석)
+     * - 댓글 히스토그램 (시간대별 분포)
+     * - 인기 타임스탬프
+     * - 좋아요 TOP 5 댓글
+     */
+    @GetMapping("/{apiVideoId}/analysis")
+    public ResponseEntity<ResponseDto<VideoAnalysisResponse>> getVideoAnalysis(
+            @PathVariable String apiVideoId) {
+        try {
+            log.info("영상 분석 정보 조회 요청: apiVideoId={}", apiVideoId);
+
+            VideoAnalysisResponse result = videoDetailService.getVideoAnalysis(apiVideoId);
+
+            log.info("영상 분석 정보 조회 완료: apiVideoId={}", apiVideoId);
+            return ResponseEntity.ok(ResponseDto.of(result, "영상 분석 정보 조회 성공"));
+
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 요청: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(ResponseDto.of(e.getMessage()));
+
+        } catch (Exception e) {
+            log.error("영상 분석 정보 조회 실패: apiVideoId={}, error={}", apiVideoId, e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(ResponseDto.of("영상 분석 정보 조회 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * 전체 댓글 조회
+     * - 최대 100개
+     */
+    @GetMapping("/{apiVideoId}/comments/all")
+    public ResponseEntity<ResponseDto<List<DetailCommentDto>>> getVideoComments(
+            @PathVariable String apiVideoId) {
+        try {
+            log.info("전체 댓글 조회 요청: apiVideoId={}", apiVideoId);
+
+            List<DetailCommentDto> result = videoDetailService.getVideoComments(apiVideoId);
+
+            log.info("전체 댓글 조회 완료: apiVideoId={}, 댓글 수={}", apiVideoId, result.size());
+            return ResponseEntity.ok(ResponseDto.of(result, "전체 댓글 조회 성공"));
+
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 요청: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(ResponseDto.of(e.getMessage()));
+
+        } catch (Exception e) {
+            log.error("전체 댓글 조회 실패: apiVideoId={}, error={}", apiVideoId, e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(ResponseDto.of("전체 댓글 조회 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * AI 분석 결과 조회
+     * - AI 요약
+     * - 언어 분포
+     * - 감정 분포
+     * - 키워드
+     */
+    @GetMapping("/{apiVideoId}/ai")
+    public ResponseEntity<ResponseDto<AIAnalysisResponse>> getAIAnalysis(
+            @PathVariable String apiVideoId) {
+        try {
+            log.info("AI 분석 결과 조회 요청: apiVideoId={}", apiVideoId);
+
+            AIAnalysisResponse result = videoDetailService.getAIAnalysis(apiVideoId);
+
+            log.info("AI 분석 결과 조회 완료: apiVideoId={}", apiVideoId);
+            return ResponseEntity.ok(ResponseDto.of(result, "AI 분석 결과 조회 성공"));
+
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 요청: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(ResponseDto.of(e.getMessage()));
+
+        } catch (Exception e) {
+            log.error("AI 분석 결과 조회 실패: apiVideoId={}, error={}", apiVideoId, e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(ResponseDto.of("AI 분석 결과 조회 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * @deprecated 기존 통합 API - 하위 호환성을 위해 유지
+     * 프론트엔드 마이그레이션 후 제거 예정
+     */
+    @Deprecated
     @GetMapping("/{apiVideoId}")
     public ResponseEntity<ResponseDto<DetailPageResponse>> getVideoDetail(
             @CookieValue(value = "Authorization", required = false) String token,
             @PathVariable String apiVideoId) {
+
+        log.warn("Deprecated API 호출: GET /api/videos/{} - 새로운 분리된 API 사용을 권장합니다.", apiVideoId);
+
         try {
             log.info("비디오 상세 정보 요청: apiVideoId={}", apiVideoId);
 
-            DetailPageResponse result = videoProcessingService.processVideoToSearchResult(token, apiVideoId, true);
+            DetailPageResponse result = videoDetailService.getVideoDetail(token, apiVideoId);
 
             log.info("비디오 상세 정보 조회 완료: apiVideoId={}", apiVideoId);
-            return ResponseEntity.ok(ResponseDto.of(result, "비디오 상세 정보 조회 성공"));
+            return ResponseEntity.ok(ResponseDto.of(result, "비디오 상세 정보 조회 성공 (Deprecated)"));
 
         } catch (IllegalArgumentException e) {
             log.warn("잘못된 요청: {}", e.getMessage());

--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/dto/AIAnalysisResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/dto/AIAnalysisResponse.java
@@ -1,0 +1,12 @@
+package com.knu.sosuso.capstone.domain.detail.dto;
+
+import java.util.List;
+
+public record AIAnalysisResponse(
+        String summary,
+        Boolean isWarning,
+        List<DetailAnalysisDto.LanguageDistribution> languageDistribution,
+        DetailAnalysisDto.SentimentDistribution sentimentDistribution,
+        List<String> keywords
+) {
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/dto/VideoAnalysisResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/dto/VideoAnalysisResponse.java
@@ -1,0 +1,10 @@
+package com.knu.sosuso.capstone.domain.detail.dto;
+
+import java.util.List;
+
+public record VideoAnalysisResponse(
+        List<DetailAnalysisDto.CommentHistogram> commentHistogram,
+        List<DetailAnalysisDto.PopularTimestamp> popularTimestamps,
+        List<DetailCommentDto> topComments
+) {
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/dto/VideoBasicResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/dto/VideoBasicResponse.java
@@ -1,0 +1,7 @@
+package com.knu.sosuso.capstone.domain.detail.dto;
+
+public record VideoBasicResponse(
+        DetailVideoDto video,
+        DetailChannelDto channel
+) {
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
@@ -1,0 +1,261 @@
+package com.knu.sosuso.capstone.domain.detail.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.knu.sosuso.capstone.domain.conmment.repository.CommentRepository;
+import com.knu.sosuso.capstone.domain.detail.dto.*;
+import com.knu.sosuso.capstone.domain.video.entity.Video;
+import com.knu.sosuso.capstone.domain.video.repository.VideoRepository;
+import com.knu.sosuso.capstone.domain.video.service.UserDataService;
+import com.knu.sosuso.capstone.domain.video.service.VideoProcessingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class VideoDetailService {
+
+    private final VideoRepository videoRepository;
+    private final CommentRepository commentRepository;
+    private final UserDataService userDataService;
+    private final VideoProcessingService videoProcessingService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 영상 기본 정보 조회
+     */
+    @Transactional(readOnly = true)
+    public VideoBasicResponse getVideoBasic(String token, String apiVideoId) {
+        log.info("영상 기본 정보 조회: apiVideoId={}", apiVideoId);
+
+        // DB에서 조회 시도
+        Video video = videoRepository.findByApiVideoId(apiVideoId).orElse(null);
+
+        if (video == null) {
+            // DB에 없으면 YouTube API에서 수집 (AI 없이)
+            log.info("DB에 없는 영상, YouTube API에서 수집: apiVideoId={}", apiVideoId);
+            DetailPageResponse fullResponse = videoProcessingService.processVideoToSearchResult(
+                    token, apiVideoId, false);
+
+            return new VideoBasicResponse(
+                    fullResponse.video(),
+                    fullResponse.channel()
+            );
+        }
+
+        // DB에서 기본 정보 반환
+        Long scrapId = userDataService.getUserScrapId(token, apiVideoId);
+        Long favoriteChannelId = userDataService.getUserFavoriteChannelId(token, video.getChannelId());
+
+        DetailVideoDto videoDto = new DetailVideoDto(
+                video.getApiVideoId(),
+                video.getTitle(),
+                video.getDescription(),
+                video.getUploadedAt(),
+                video.getThumbnailUrl(),
+                parseLong(video.getViewCount()),
+                parseLong(video.getLikeCount()),
+                parseInt(video.getCommentCount()),
+                scrapId
+        );
+
+        DetailChannelDto channelDto = new DetailChannelDto(
+                video.getChannelId(),
+                video.getChannelName(),
+                video.getChannelThumbnailUrl(),
+                parseLong(video.getSubscriberCount()),
+                favoriteChannelId
+        );
+
+        log.info("영상 기본 정보 조회 완료: apiVideoId={}", apiVideoId);
+        return new VideoBasicResponse(videoDto, channelDto);
+    }
+
+    /**
+     * 영상 분석 정보 조회 (백엔드 분석 + TOP 5 댓글)
+     */
+    @Transactional(readOnly = true)
+    public VideoAnalysisResponse getVideoAnalysis(String apiVideoId) {
+        log.info("영상 분석 정보 조회: apiVideoId={}", apiVideoId);
+
+        Video video = videoRepository.findByApiVideoId(apiVideoId)
+                .orElseThrow(() -> new IllegalArgumentException("영상을 찾을 수 없습니다: " + apiVideoId));
+
+        // 댓글 히스토그램
+        Map<Integer, Integer> commentHistogramData = parseJsonToMap(
+                video.getCommentHistogram(), Integer.class, Integer.class);
+        List<DetailAnalysisDto.CommentHistogram> commentHistogram =
+                commentHistogramData.entrySet().stream()
+                        .map(e -> new DetailAnalysisDto.CommentHistogram(String.valueOf(e.getKey()), e.getValue()))
+                        .collect(Collectors.toList());
+
+        // 인기 타임스탬프
+        Map<String, Integer> popularTimestampsData = parseJsonToMap(
+                video.getPopularTimestamps(), String.class, Integer.class);
+        List<DetailAnalysisDto.PopularTimestamp> popularTimestamps =
+                popularTimestampsData.entrySet().stream()
+                        .map(e -> new DetailAnalysisDto.PopularTimestamp(e.getKey(), e.getValue()))
+                        .collect(Collectors.toList());
+
+        // TOP 5 댓글
+        List<DetailCommentDto> topComments = commentRepository
+                .findByVideoIdOrderByLikeCountDesc(video.getId())
+                .stream()
+                .limit(5)
+                .map(c -> new DetailCommentDto(
+                        c.getApiCommentId(),
+                        c.getWriter(),
+                        c.getCommentContent(),
+                        c.getLikeCount(),
+                        c.getSentimentType() != null ? c.getSentimentType().name() : null,
+                        c.getWrittenAt()
+                ))
+                .collect(Collectors.toList());
+
+        log.info("영상 분석 정보 조회 완료: apiVideoId={}, TOP 댓글 수={}", apiVideoId, topComments.size());
+        return new VideoAnalysisResponse(commentHistogram, popularTimestamps, topComments);
+    }
+
+    /**
+     * 전체 댓글 조회
+     */
+    @Transactional(readOnly = true)
+    public List<DetailCommentDto> getVideoComments(String apiVideoId) {
+        log.info("전체 댓글 조회: apiVideoId={}", apiVideoId);
+
+        Video video = videoRepository.findByApiVideoId(apiVideoId)
+                .orElseThrow(() -> new IllegalArgumentException("영상을 찾을 수 없습니다: " + apiVideoId));
+
+        List<DetailCommentDto> comments = commentRepository.findByVideoIdOrderByIdAsc(video.getId())
+                .stream()
+                .map(c -> new DetailCommentDto(
+                        c.getApiCommentId(),
+                        c.getWriter(),
+                        c.getCommentContent(),
+                        c.getLikeCount(),
+                        c.getSentimentType() != null ? c.getSentimentType().name() : null,
+                        c.getWrittenAt()
+                ))
+                .collect(Collectors.toList());
+
+        log.info("전체 댓글 조회 완료: apiVideoId={}, 댓글 수={}", apiVideoId, comments.size());
+        return comments;
+    }
+
+    /**
+     * AI 분석 결과 조회
+     */
+    @Transactional(readOnly = true)
+    public AIAnalysisResponse getAIAnalysis(String apiVideoId) {
+        log.info("AI 분석 결과 조회: apiVideoId={}", apiVideoId);
+
+        Video video = videoRepository.findByApiVideoId(apiVideoId)
+                .orElseThrow(() -> new IllegalArgumentException("영상을 찾을 수 없습니다: " + apiVideoId));
+
+        // AI 분석 완료 여부 체크
+        boolean hasAIAnalysis = video.getSummation() != null &&
+                video.getLanguageDistribution() != null &&
+                video.getSentimentDistribution() != null &&
+                video.getKeywords() != null;
+
+        if (!hasAIAnalysis) {
+            log.info("AI 분석이 아직 완료되지 않음: apiVideoId={}", apiVideoId);
+            // 빈 응답 반환 (프론트에서 "분석 중" 표시)
+            return new AIAnalysisResponse(
+                    null,
+                    false,
+                    new ArrayList<>(),
+                    new DetailAnalysisDto.SentimentDistribution(0.0, 0.0, 0.0),
+                    new ArrayList<>()
+            );
+        }
+
+        // 언어 분포
+        Map<String, Double> languageRatio = parseJsonToMap(
+                video.getLanguageDistribution(), String.class, Double.class);
+        List<DetailAnalysisDto.LanguageDistribution> languageDistribution =
+                languageRatio.entrySet().stream()
+                        .map(e -> new DetailAnalysisDto.LanguageDistribution(e.getKey(), e.getValue()))
+                        .collect(Collectors.toList());
+
+        // 감정 분포
+        Map<String, Double> sentimentRatio = parseJsonToMap(
+                video.getSentimentDistribution(), String.class, Double.class);
+        DetailAnalysisDto.SentimentDistribution sentimentDistribution =
+                new DetailAnalysisDto.SentimentDistribution(
+                        sentimentRatio.getOrDefault("positive", 0.0),
+                        sentimentRatio.getOrDefault("negative", 0.0),
+                        sentimentRatio.getOrDefault("other", 0.0)
+                );
+
+        // 키워드
+        List<String> keywords = new ArrayList<>();
+        try {
+            keywords = objectMapper.readValue(video.getKeywords(), new TypeReference<>() {
+            });
+        } catch (Exception e) {
+            log.warn("키워드 파싱 실패: {}", e.getMessage());
+        }
+
+        log.info("AI 분석 결과 조회 완료: apiVideoId={}", apiVideoId);
+        return new AIAnalysisResponse(
+                video.getSummation(),
+                video.isWarning(),
+                languageDistribution,
+                sentimentDistribution,
+                keywords
+        );
+    }
+
+    /**
+     * @deprecated 기존 통합 API
+     */
+    @Deprecated
+    @Transactional
+    public DetailPageResponse getVideoDetail(String token, String apiVideoId) {
+        log.warn("Deprecated 메서드 호출: getVideoDetail() - 분리된 메서드 사용 권장");
+        return videoProcessingService.processVideoToSearchResult(token, apiVideoId, true);
+    }
+
+    // ==================== Helper Methods ====================
+
+    private <K, V> Map<K, V> parseJsonToMap(String json, Class<K> keyClass, Class<V> valueClass) {
+        if (json == null || json.trim().isEmpty()) {
+            return new HashMap<>();
+        }
+        try {
+            return objectMapper.readValue(json,
+                    objectMapper.getTypeFactory().constructMapType(Map.class, keyClass, valueClass));
+        } catch (Exception e) {
+            log.warn("JSON 파싱 실패: {}", e.getMessage());
+            return new HashMap<>();
+        }
+    }
+
+    private Long parseLong(String value) {
+        try {
+            return value != null && !value.isEmpty() ? Long.parseLong(value) : 0L;
+        } catch (NumberFormatException e) {
+            log.warn("Long 변환 실패: {}", value);
+            return 0L;
+        }
+    }
+
+    private Integer parseInt(String value) {
+        try {
+            return value != null && !value.isEmpty() ? Integer.parseInt(value) : 0;
+        } catch (NumberFormatException e) {
+            log.warn("Integer 변환 실패: {}", value);
+            return 0;
+        }
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/main/MainPageController.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/main/MainPageController.java
@@ -4,6 +4,7 @@ import com.knu.sosuso.capstone.domain.channel.dto.response.FavoriteChannelListRe
 import com.knu.sosuso.capstone.domain.channel.dto.response.FavoriteVideoInfoResponse;
 import com.knu.sosuso.capstone.domain.video.dto.response.VideoSummaryResponse;
 import com.knu.sosuso.capstone.global.ResponseDto;
+import com.knu.sosuso.capstone.global.swagger.MainPageControllerSwagger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +16,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/main")
-public class MainPageController {
+public class MainPageController implements MainPageControllerSwagger {
 
     private final MainPageService mainPageService;
 

--- a/src/main/java/com/knu/sosuso/capstone/domain/main/MainPageController.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/main/MainPageController.java
@@ -1,13 +1,15 @@
 package com.knu.sosuso.capstone.domain.main;
 
+import com.knu.sosuso.capstone.domain.channel.dto.response.FavoriteChannelListResponse;
+import com.knu.sosuso.capstone.domain.channel.dto.response.FavoriteVideoInfoResponse;
+import com.knu.sosuso.capstone.domain.video.dto.response.VideoSummaryResponse;
 import com.knu.sosuso.capstone.global.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -17,22 +19,96 @@ public class MainPageController {
 
     private final MainPageService mainPageService;
 
-    @GetMapping()
+    /**
+     * 메인 페이지 - 관심 채널 섹션
+     * 관심 채널 목록 + 첫 번째 채널의 최신 영상 1개
+     */
+    @GetMapping("/favorite-channels")
+    public ResponseEntity<ResponseDto<MainPageResponse.FavoriteChannelResponse>> getFavoriteChannels(
+            @CookieValue(value = "Authorization", required = false) String token) {
+
+        log.info("메인 페이지 - 관심 채널 섹션 조회 요청");
+
+        try {
+            MainPageResponse.FavoriteChannelResponse response =
+                    mainPageService.getFavoriteChannelResponse(token);
+
+            log.info("관심 채널 섹션 조회 성공: 채널 수={}",
+                    response.favoriteChannelList() != null ? response.favoriteChannelList().size() : 0);
+
+            return ResponseEntity.ok(ResponseDto.of(response, "관심 채널 섹션 조회 완료"));
+
+        } catch (Exception e) {
+            log.error("관심 채널 섹션 조회 실패: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(ResponseDto.of("관심 채널 섹션 조회 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * 메인 페이지 - 인기 급상승 섹션
+     * 최신 인기 급상승 영상 3개
+     */
+    @GetMapping("/trending")
+    public ResponseEntity<ResponseDto<List<VideoSummaryResponse>>> getTrending(
+            @CookieValue(value = "Authorization", required = false) String token) {
+
+        log.info("메인 페이지 - 인기 급상승 섹션 조회 요청");
+
+        try {
+            List<VideoSummaryResponse> response = mainPageService.getTrendingVideos(token);
+
+            log.info("인기 급상승 섹션 조회 성공: 영상 수={}", response.size());
+            return ResponseEntity.ok(ResponseDto.of(response, "인기 급상승 섹션 조회 완료"));
+
+        } catch (Exception e) {
+            log.error("인기 급상승 섹션 조회 실패: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(ResponseDto.of("인기 급상승 섹션 조회 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * 메인 페이지 - 스크랩 섹션
+     * 사용자가 스크랩한 영상 목록 (최대 3개)
+     */
+    @GetMapping("/scraps")
+    public ResponseEntity<ResponseDto<List<VideoSummaryResponse>>> getScraps(
+            @CookieValue(value = "Authorization") String token) {
+
+        log.info("메인 페이지 - 스크랩 섹션 조회 요청");
+
+        try {
+            List<VideoSummaryResponse> response = mainPageService.getScrapVideos(token);
+
+            log.info("스크랩 섹션 조회 성공: 영상 수={}", response.size());
+            return ResponseEntity.ok(ResponseDto.of(response, "스크랩 섹션 조회 완료"));
+
+        } catch (Exception e) {
+            log.error("스크랩 섹션 조회 실패: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError()
+                    .body(ResponseDto.of("스크랩 섹션 조회 중 오류가 발생했습니다."));
+        }
+    }
+
+    /**
+     * @deprecated 기존 통합 API - 하위 호환성을 위해 유지
+     * 프론트엔드 마이그레이션 후 제거 예정
+     */
+    @Deprecated
+    @GetMapping
     public ResponseEntity<ResponseDto<MainPageResponse>> getMainPageData(
             @CookieValue(value = "Authorization", required = false) String token) {
 
-        log.info("메인 페이지 데이터 조회 요청 수신");
+        log.warn("Deprecated API 호출: GET /api/main - 새로운 분리된 API 사용을 권장합니다.");
 
         try {
             MainPageResponse response = mainPageService.getMainPageData(token);
-
-            log.info("메인 페이지 데이터 조회 성공");
-            return ResponseEntity.ok(ResponseDto.of(response, "메인 페이지 조회 완료"));
+            return ResponseEntity.ok(ResponseDto.of(response, "메인 페이지 조회 완료 (Deprecated)"));
 
         } catch (Exception e) {
             log.error("메인 페이지 데이터 조회 실패: {}", e.getMessage(), e);
             throw e;
         }
     }
-
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/main/MainPageService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/main/MainPageService.java
@@ -33,16 +33,143 @@ public class MainPageService {
     private final FavoriteChannelRepository favoriteChannelRepository;
     private final JwtUtil jwtUtil;
 
+    /**
+     * 관심 채널 섹션 데이터 조회
+     * - 토큰이 없거나 유효하지 않으면 빈 데이터 반환
+     */
+    @Transactional
+    public MainPageResponse.FavoriteChannelResponse getFavoriteChannelResponse(String token) {
+        log.info("관심 채널 섹션 데이터 조회 시작");
+
+        try {
+            // 토큰 검증
+            if (!StringUtils.hasText(token) || !jwtUtil.isValidToken(token)) {
+                log.info("토큰 없음 또는 유효하지 않음 - 빈 관심 채널 반환");
+                return createEmptyFavoriteChannelResponse();
+            }
+
+            Long userId = jwtUtil.getUserId(token);
+
+            // 관심 채널 목록 조회
+            List<FavoriteChannelListResponse> favoriteChannelList =
+                    favoriteChannelService.getFavoriteChannelList(token);
+
+            if (favoriteChannelList.isEmpty()) {
+                log.info("관심 채널이 없습니다");
+                return new MainPageResponse.FavoriteChannelResponse(
+                        new ArrayList<>(),
+                        null
+                );
+            }
+
+            // 첫 번째 채널의 최신 영상 조회
+            FavoriteChannelListResponse selectedChannel = favoriteChannelList.get(0);
+            log.debug("선택된 채널: {}", selectedChannel.apiChannelName());
+
+            long favoriteChannelId = selectedChannel.favoriteChannelId();
+            Optional<FavoriteChannel> favoriteChannelOpt =
+                    favoriteChannelRepository.findByIdAndUserId(favoriteChannelId, userId);
+
+            if (favoriteChannelOpt.isPresent()) {
+                String apiChannelId = favoriteChannelOpt.get().getApiChannelId();
+
+                // 해당 채널의 최신 비디오 1개 조회
+                FavoriteVideoInfoResponse channelVideo =
+                        favoriteChannelService.processLatestVideoFromFavoriteChannel(token, apiChannelId);
+
+                log.info("관심 채널 섹션 조회 성공: 채널 수={}, 최신 영상 있음",
+                        favoriteChannelList.size());
+
+                return new MainPageResponse.FavoriteChannelResponse(
+                        favoriteChannelList,
+                        channelVideo
+                );
+            }
+
+            log.warn("관심 채널을 찾을 수 없음: favoriteChannelId={}", favoriteChannelId);
+            return new MainPageResponse.FavoriteChannelResponse(
+                    favoriteChannelList,
+                    null
+            );
+
+        } catch (Exception e) {
+            log.error("관심 채널 섹션 조회 실패: {}", e.getMessage(), e);
+            return createEmptyFavoriteChannelResponse();
+        }
+    }
+
+    /**
+     * 인기 급상승 섹션 데이터 조회 (최대 3개)
+     * - 인증 불필요, 모든 사용자에게 동일하게 제공
+     */
+    @Transactional
+    public List<VideoSummaryResponse> getTrendingVideos(String token) {
+        log.info("인기 급상승 섹션 데이터 조회 시작");
+
+        try {
+            List<VideoSummaryResponse> trendingVideos =
+                    trendingService.getTrendingVideoWithComments(token, "latest", 3);
+
+            log.info("인기 급상승 섹션 조회 완료: 영상 수={}", trendingVideos.size());
+            return trendingVideos;
+
+        } catch (Exception e) {
+            log.error("인기 급상승 섹션 조회 실패: {}", e.getMessage(), e);
+            return new ArrayList<>(); // 실패해도 빈 리스트 반환하여 다른 섹션에 영향 없도록
+        }
+    }
+
+    /**
+     * 스크랩 섹션 데이터 조회 (최대 3개)
+     * - 인증 필수
+     */
+    @Transactional
+    public List<VideoSummaryResponse> getScrapVideos(String token) {
+        log.info("스크랩 섹션 데이터 조회 시작");
+
+        try {
+            List<VideoSummaryResponse> allScrapVideos = scrapService.getScrappedVideos(token);
+
+            // 최대 3개까지만 반환
+            int maxSize = Math.min(allScrapVideos.size(), 3);
+            List<VideoSummaryResponse> limitedScrapVideos = allScrapVideos.subList(0, maxSize);
+
+            log.info("스크랩 섹션 조회 완료: 전체={}, 반환={}",
+                    allScrapVideos.size(), limitedScrapVideos.size());
+
+            return limitedScrapVideos;
+
+        } catch (Exception e) {
+            log.error("스크랩 섹션 조회 실패: {}", e.getMessage(), e);
+            return new ArrayList<>(); // 실패해도 빈 리스트 반환
+        }
+    }
+
+    /**
+     * 빈 관심 채널 응답 생성
+     */
+    private MainPageResponse.FavoriteChannelResponse createEmptyFavoriteChannelResponse() {
+        return new MainPageResponse.FavoriteChannelResponse(
+                Collections.emptyList(),
+                null
+        );
+    }
+
+    // ==================== 기존 통합 API (Deprecated) ====================
+
+    /**
+     * @deprecated 기존 통합 메인 페이지 데이터 조회
+     * 프론트엔드 마이그레이션 후 제거 예정
+     */
+    @Deprecated
     @Transactional
     public MainPageResponse getMainPageData(String token) {
-        log.info("메인 페이지 데이터 조회 시작");
+        log.warn("Deprecated 메서드 호출: getMainPageData() - 분리된 메서드 사용 권장");
 
         try {
             if (StringUtils.hasText(token) && jwtUtil.isValidToken(token)) {
-                // 인증된 사용자용 메인 페이지
                 return getAuthenticatedMainPageData(token);
             } else {
-                // 비인증 사용자용 메인 페이지
                 return getGuestMainPageData();
             }
 
@@ -52,149 +179,31 @@ public class MainPageService {
         }
     }
 
-    // 인증된 사용자용 메인 페이지 데이터
+    @Deprecated
     @Transactional
     public MainPageResponse getAuthenticatedMainPageData(String token) {
-        log.info("인증된 사용자 메인 페이지 데이터 조회");
-
         List<VideoSummaryResponse> scrapVideos = getScrapVideos(token);
-        List<VideoSummaryResponse> trendingVideos = getTrendingVideos();
+        List<VideoSummaryResponse> trendingVideos = getTrendingVideos(token);
         MainPageResponse.FavoriteChannelResponse favoriteChannelResponse = getFavoriteChannelResponse(token);
 
-        MainPageResponse response = new MainPageResponse(
+        return new MainPageResponse(
                 favoriteChannelResponse,
                 trendingVideos,
                 scrapVideos
         );
-
-        log.info("인증된 사용자 메인 페이지 데이터 조회 완료: 스크랩={}, 트렌딩={}, 즐겨찾기 채널={}",
-                scrapVideos.size(),
-                trendingVideos.size(),
-                favoriteChannelResponse.favoriteChannelList() != null
-                        ? favoriteChannelResponse.favoriteChannelList().size() : 0);
-
-        return response;
     }
 
-    // 비인증 사용자용 메인 페이지 데이터
+    @Deprecated
     @Transactional
     public MainPageResponse getGuestMainPageData() {
-        log.info("비인증 사용자 메인 페이지 데이터 조회");
+        List<VideoSummaryResponse> trendingVideos = getTrendingVideos(null);
+        MainPageResponse.FavoriteChannelResponse emptyFavoriteChannelResponse =
+                createEmptyFavoriteChannelResponse();
 
-        List<VideoSummaryResponse> trendingVideos = getTrendingVideos();
-        MainPageResponse.FavoriteChannelResponse emptyFavoriteChannelResponse = createEmptyFavoriteChannelResponse();
-
-        MainPageResponse response = new MainPageResponse(
+        return new MainPageResponse(
                 emptyFavoriteChannelResponse,
                 trendingVideos,
-                Collections.emptyList() // 스크랩 비디오 없음
+                Collections.emptyList()
         );
-
-        log.info("비인증 사용자 메인 페이지 데이터 조회 완료: 트렌딩={}", trendingVideos.size());
-
-        return response;
-    }
-
-    // 트렌딩 비디오는 토큰 없이도 조회 가능하도록 오버로드
-    @Transactional
-    public List<VideoSummaryResponse> getTrendingVideos() {
-        return getTrendingVideos(null);
-    }
-
-    // 빈 즐겨찾기 채널 응답 생성
-    private MainPageResponse.FavoriteChannelResponse createEmptyFavoriteChannelResponse() {
-        return new MainPageResponse.FavoriteChannelResponse(
-                Collections.emptyList(),
-                null
-        );
-    }
-
-
-    /**
-     * 스크랩된 비디오 목록 조회 (최대 3개)
-     */
-    @Transactional
-    public List<VideoSummaryResponse> getScrapVideos(String token) {
-        try {
-            List<VideoSummaryResponse> allScrapVideos = scrapService.getScrappedVideos(token);
-
-            // 최대 3개까지만 반환
-            int maxSize = Math.min(allScrapVideos.size(), 3);
-            List<VideoSummaryResponse> limitedScrapVideos = allScrapVideos.subList(0, maxSize);
-
-            log.debug("스크랩 비디오 조회 완료: 전체={}, 반환={}", allScrapVideos.size(), limitedScrapVideos.size());
-            return limitedScrapVideos;
-
-        } catch (Exception e) {
-            log.error("스크랩 비디오 조회 실패: {}", e.getMessage(), e);
-            return new ArrayList<>(); // 실패해도 빈 리스트 반환하여 다른 섹션에 영향주지 않음
-        }
-    }
-
-    /**
-     * 트렌딩 비디오 목록 조회 (최대 3개)
-     */
-    @Transactional
-    public List<VideoSummaryResponse> getTrendingVideos(String token) {
-        try {
-            List<VideoSummaryResponse> trendingVideos = trendingService.getTrendingVideoWithComments(token, "latest", 3);
-            log.debug("트렌딩 비디오 조회 완료: 개수={}", trendingVideos.size());
-            return trendingVideos;
-
-        } catch (Exception e) {
-            log.error("트렌딩 비디오 조회 실패: {}", e.getMessage(), e);
-            return new ArrayList<>(); // 실패해도 빈 리스트 반환
-        }
-    }
-
-    /**
-     * 즐겨찾기 채널 응답 생성
-     */
-    @Transactional
-    public MainPageResponse.FavoriteChannelResponse getFavoriteChannelResponse(String token) {
-        if (!jwtUtil.isValidToken(token)) {
-            throw new BusinessException(AuthenticationError.INVALID_TOKEN);
-        }
-
-        Long userId = jwtUtil.getUserId(token);
-
-        // 즐겨찾기 채널 목록 조회
-        List<FavoriteChannelListResponse> favoriteChannelList = favoriteChannelService.getFavoriteChannelList(token);
-
-        if (favoriteChannelList.isEmpty()) {
-            log.info("즐겨찾기 채널이 없습니다");
-            return new MainPageResponse.FavoriteChannelResponse(
-                    new ArrayList<>(),
-                    null
-            );
-        }
-
-        FavoriteChannelListResponse selectedChannel = favoriteChannelList.get(0);
-        log.debug("선택된 채널: {}", selectedChannel.apiChannelName());
-
-        long favoriteChannelId = selectedChannel.favoriteChannelId();
-
-        Optional<FavoriteChannel> favoriteChannelOpt = favoriteChannelRepository.findByIdAndUserId(favoriteChannelId, userId);
-
-        try {
-            if (favoriteChannelOpt.isPresent()) {
-                String apiChannelId = favoriteChannelOpt.get().getApiChannelId();
-
-                // 해당 채널의 최신 비디오 하나와 댓글 조회
-                FavoriteVideoInfoResponse channelVideo = favoriteChannelService.processLatestVideoFromFavoriteChannel(token, apiChannelId);
-
-                return new MainPageResponse.FavoriteChannelResponse(
-                        favoriteChannelList,
-                        channelVideo
-                );
-            }
-        } catch (Exception e) {
-            log.error("즐겨찾기 채널 응답 생성 실패: {}", e.getMessage(), e);
-            return new MainPageResponse.FavoriteChannelResponse(
-                    new ArrayList<>(),
-                    null
-            );
-        }
-        return null;
     }
 }

--- a/src/main/java/com/knu/sosuso/capstone/global/swagger/MainPageControllerSwagger.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/swagger/MainPageControllerSwagger.java
@@ -1,0 +1,261 @@
+package com.knu.sosuso.capstone.global.swagger;
+
+import com.knu.sosuso.capstone.domain.channel.dto.response.FavoriteChannelListResponse;
+import com.knu.sosuso.capstone.domain.main.MainPageResponse;
+import com.knu.sosuso.capstone.domain.video.dto.response.VideoSummaryResponse;
+import com.knu.sosuso.capstone.global.ResponseDto;
+import com.knu.sosuso.capstone.global.exception.ErrorResponse;
+import com.knu.sosuso.capstone.global.swagger.annotation.ErrorCode400;
+import com.knu.sosuso.capstone.global.swagger.annotation.ErrorCode500;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+
+import java.util.List;
+
+@Tag(
+        name = "메인 페이지 API",
+        description = "메인 페이지의 섹션별 데이터를 제공하는 API입니다. " +
+                "관심 채널, 인기 급상승, 스크랩 섹션을 독립적으로 조회할 수 있습니다."
+)
+public interface MainPageControllerSwagger {
+
+    @Operation(
+            summary = "메인 페이지 - 관심 채널 섹션",
+            description = "사용자의 관심 채널 목록과 첫 번째 채널의 최신 영상 정보를 제공합니다.\n\n" +
+                    "**제공 정보:**\n" +
+                    "- 관심 채널 목록\n" +
+                    "- 첫 번째 채널의 최신 업로드 영상 1개 (영상 정보, 채널 정보, AI 분석 포함)\n\n" +
+                    "**인증:**\n" +
+                    "- 토큰 없음/유효하지 않음 → 빈 데이터 반환\n" +
+                    "- 유효한 토큰 → 사용자의 관심 채널 데이터 반환",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "관심 채널 섹션 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseDto.class),
+                                    examples = {
+                                            @ExampleObject(
+                                                    name = "로그인 사용자 - 관심 채널 있음",
+                                                    value = """
+                                                            {
+                                                              "timeStamp": "2025-01-20T10:00:00",
+                                                              "message": "관심 채널 섹션 조회 완료",
+                                                              "data": {
+                                                                "favoriteChannelList": [
+                                                                  {
+                                                                    "favoriteChannelId": 1,
+                                                                    "apiChannelId": "UCxxxxxxxx",
+                                                                    "apiChannelName": "채널명",
+                                                                    "apiChannelThumbnail": "https://..."
+                                                                  }
+                                                                ],
+                                                                "latestVideo": {
+                                                                  "video": {
+                                                                    "id": "videoId123",
+                                                                    "title": "최신 영상 제목",
+                                                                    "description": "영상 설명...",
+                                                                    "publishedAt": "2025-01-20T00:00:00Z",
+                                                                    "thumbnailUrl": "https://...",
+                                                                    "viewCount": 10000,
+                                                                    "likeCount": 500,
+                                                                    "commentCount": 100
+                                                                  },
+                                                                  "channel": {
+                                                                    "id": "UCxxxxxxxx",
+                                                                    "title": "채널명",
+                                                                    "thumbnailUrl": "https://...",
+                                                                    "subscriberCount": 100000
+                                                                  },
+                                                                  "analysis": {
+                                                                    "summary": "AI 요약 내용...",
+                                                                    "sentimentDistribution": {
+                                                                      "positive": 0.6,
+                                                                      "negative": 0.2,
+                                                                      "other": 0.2
+                                                                    },
+                                                                    "keywords": ["키워드1", "키워드2"],
+                                                                    "topComments": [...]
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                            """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "비로그인 사용자 또는 관심 채널 없음",
+                                                    value = """
+                                                            {
+                                                              "timeStamp": "2025-01-20T10:00:00",
+                                                              "message": "관심 채널 섹션 조회 완료",
+                                                              "data": {
+                                                                "favoriteChannelList": [],
+                                                                "latestVideo": null
+                                                              }
+                                                            }
+                                                            """
+                                            )
+                                    }
+                            )
+                    )
+            }
+    )
+    @Parameter(
+            name = "Authorization",
+            description = "JWT 토큰 (Cookie) - 선택사항",
+            required = false,
+            in = ParameterIn.COOKIE,
+            schema = @Schema(type = "string", format = "jwt")
+    )
+    @ErrorCode500
+    ResponseEntity<ResponseDto<MainPageResponse.FavoriteChannelResponse>> getFavoriteChannels(
+            @CookieValue(value = "Authorization", required = false) String token
+    );
+
+    @Operation(
+            summary = "메인 페이지 - 인기 급상승 섹션",
+            description = "한국(KR) 기준 최신 인기 급상승 영상 3개를 제공합니다.\n\n" +
+                    "**제공 정보:**\n" +
+                    "- 영상 기본 정보\n" +
+                    "- 채널 정보\n" +
+                    "- AI 분석 결과 (요약, 감정, 키워드 등)\n\n" +
+                    "**특징:**\n" +
+                    "- 인증 불필요 (모든 사용자 동일 데이터)\n" +
+                    "- 로그인 시 스크랩/관심채널 ID 추가 제공",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "인기 급상승 섹션 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseDto.class),
+                                    examples = @ExampleObject(
+                                            name = "인기 급상승 영상 목록",
+                                            value = """
+                                                    {
+                                                      "timeStamp": "2025-01-20T10:00:00",
+                                                      "message": "인기 급상승 섹션 조회 완료",
+                                                      "data": [
+                                                        {
+                                                          "video": {
+                                                            "id": "trending1",
+                                                            "title": "인기 영상 1",
+                                                            "description": "설명...",
+                                                            "publishedAt": "2025-01-19T00:00:00Z",
+                                                            "thumbnailUrl": "https://...",
+                                                            "viewCount": 500000,
+                                                            "likeCount": 20000,
+                                                            "commentCount": 3000
+                                                          },
+                                                          "channel": {
+                                                            "id": "UCyyyyyyyy",
+                                                            "title": "인기 채널",
+                                                            "thumbnailUrl": "https://...",
+                                                            "subscriberCount": 1000000
+                                                          },
+                                                          "analysis": {
+                                                            "summary": "AI 요약...",
+                                                            "sentimentDistribution": {
+                                                              "positive": 0.7,
+                                                              "negative": 0.1,
+                                                              "other": 0.2
+                                                            },
+                                                            "keywords": ["키워드1", "키워드2"]
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    @Parameter(
+            name = "Authorization",
+            description = "JWT 토큰 (Cookie) - 선택사항",
+            required = false,
+            in = ParameterIn.COOKIE,
+            schema = @Schema(type = "string", format = "jwt")
+    )
+    @ErrorCode500
+    ResponseEntity<ResponseDto<List<VideoSummaryResponse>>> getTrending(
+            @CookieValue(value = "Authorization", required = false) String token
+    );
+
+    @Operation(
+            summary = "메인 페이지 - 스크랩 섹션",
+            description = "사용자가 스크랩한 영상 목록을 최대 3개까지 제공합니다.\n\n" +
+                    "**제공 정보:**\n" +
+                    "- 스크랩한 영상 정보\n" +
+                    "- 채널 정보\n" +
+                    "- AI 분석 결과\n\n" +
+                    "**인증:** 필수 (토큰 없으면 400 에러)",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "스크랩 섹션 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseDto.class),
+                                    examples = @ExampleObject(
+                                            name = "스크랩 영상 목록",
+                                            value = """
+                                                    {
+                                                      "timeStamp": "2025-01-20T10:00:00",
+                                                      "message": "스크랩 섹션 조회 완료",
+                                                      "data": [
+                                                        {
+                                                          "video": {
+                                                            "id": "scrap1",
+                                                            "title": "스크랩한 영상",
+                                                            "description": "설명...",
+                                                            "publishedAt": "2025-01-18T00:00:00Z",
+                                                            "thumbnailUrl": "https://...",
+                                                            "viewCount": 50000,
+                                                            "likeCount": 2000,
+                                                            "commentCount": 300
+                                                          },
+                                                          "channel": {...},
+                                                          "analysis": {...}
+                                                        }
+                                                      ]
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "토큰 누락 또는 유효하지 않음",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    )
+            },
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @Parameter(
+            name = "Authorization",
+            description = "JWT 토큰 (Cookie) - 필수",
+            required = true,
+            in = ParameterIn.COOKIE,
+            schema = @Schema(type = "string", format = "jwt")
+    )
+    @ErrorCode400
+    @ErrorCode500
+    ResponseEntity<ResponseDto<List<VideoSummaryResponse>>> getScraps(
+            @CookieValue(value = "Authorization") String token
+    );
+}

--- a/src/main/java/com/knu/sosuso/capstone/global/swagger/VideoDetailControllerSwagger.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/swagger/VideoDetailControllerSwagger.java
@@ -1,0 +1,299 @@
+package com.knu.sosuso.capstone.global.swagger;
+
+import com.knu.sosuso.capstone.domain.detail.dto.*;
+import com.knu.sosuso.capstone.global.ResponseDto;
+import com.knu.sosuso.capstone.global.exception.ErrorResponse;
+import com.knu.sosuso.capstone.global.swagger.annotation.ErrorCode400;
+import com.knu.sosuso.capstone.global.swagger.annotation.ErrorCode500;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Tag(
+        name = "영상 상세 페이지 API",
+        description = "YouTube 영상의 상세 정보를 섹션별로 제공하는 API입니다. " +
+                "Progressive Loading을 위해 기본 정보, 분석, 댓글, AI 결과를 독립적으로 조회할 수 있습니다."
+)
+public interface VideoDetailControllerSwagger {
+
+    @Operation(
+            summary = "영상 기본 정보 조회",
+            description = "YouTube 영상과 채널의 기본 정보를 제공합니다.\n\n" +
+                    "**제공 정보:**\n" +
+                    "- 영상: 제목, 설명, 썸네일, 조회수, 좋아요, 댓글 수, 업로드 날짜\n" +
+                    "- 채널: 채널명, 썸네일, 구독자 수\n" +
+                    "- 사용자 데이터: 스크랩 ID, 관심 채널 ID (로그인 시)\n\n" +
+                    "**특징:** 가장 빠른 응답 (0.5-1초)",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "기본 정보 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseDto.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "timeStamp": "2025-01-20T10:00:00",
+                                                      "message": "영상 기본 정보 조회 성공",
+                                                      "data": {
+                                                        "video": {
+                                                          "id": "dQw4w9WgXcQ",
+                                                          "title": "영상 제목",
+                                                          "description": "영상 설명...",
+                                                          "publishedAt": "2025-01-15T00:00:00Z",
+                                                          "thumbnailUrl": "https://...",
+                                                          "viewCount": 1000000,
+                                                          "likeCount": 50000,
+                                                          "commentCount": 3000,
+                                                          "scrapId": 123
+                                                        },
+                                                        "channel": {
+                                                          "id": "UCxxxxxxxx",
+                                                          "title": "채널명",
+                                                          "thumbnailUrl": "https://...",
+                                                          "subscriberCount": 500000,
+                                                          "favoriteChannelId": 456
+                                                        }
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "영상을 찾을 수 없음",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
+    )
+    @Parameters({
+            @Parameter(
+                    name = "Authorization",
+                    description = "JWT 토큰 (Cookie) - 선택사항",
+                    required = false,
+                    in = ParameterIn.COOKIE,
+                    schema = @Schema(type = "string", format = "jwt")
+            ),
+            @Parameter(
+                    name = "apiVideoId",
+                    description = "YouTube 영상 ID",
+                    required = true,
+                    in = ParameterIn.PATH,
+                    example = "dQw4w9WgXcQ"
+            )
+    })
+    @ErrorCode400
+    @ErrorCode500
+    ResponseEntity<ResponseDto<VideoBasicResponse>> getVideoBasic(
+            @CookieValue(value = "Authorization", required = false) String token,
+            @PathVariable String apiVideoId
+    );
+
+    @Operation(
+            summary = "영상 분석 정보 조회",
+            description = "백엔드에서 분석한 댓글 데이터를 제공합니다.\n\n" +
+                    "**제공 정보:**\n" +
+                    "- 댓글 히스토그램 (시간대별 0-23시 분포)\n" +
+                    "- 인기 타임스탬프 (댓글에서 가장 많이 언급된 시간대 TOP 5)\n" +
+                    "- 좋아요 TOP 5 댓글\n\n" +
+                    "**특징:** 인증 불필요, DB 조회만 수행 (1-2초)",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "분석 정보 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseDto.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "timeStamp": "2025-01-20T10:00:01",
+                                                      "message": "영상 분석 정보 조회 성공",
+                                                      "data": {
+                                                        "commentHistogram": [
+                                                          {"hour": "0", "count": 10},
+                                                          {"hour": "1", "count": 15},
+                                                          {"hour": "14", "count": 150}
+                                                        ],
+                                                        "popularTimestamps": [
+                                                          {"time": "1:30", "mentionCount": 50},
+                                                          {"time": "5:30", "mentionCount": 38}
+                                                        ],
+                                                        "topComments": [
+                                                          {
+                                                            "id": "comment1",
+                                                            "author": "사용자1",
+                                                            "text": "정말 유익한 영상이네요!",
+                                                            "likeCount": 150,
+                                                            "sentiment": "POSITIVE",
+                                                            "publishedAt": "2025-01-15T10:00:00Z"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    @Parameter(
+            name = "apiVideoId",
+            description = "YouTube 영상 ID",
+            required = true,
+            in = ParameterIn.PATH,
+            example = "dQw4w9WgXcQ"
+    )
+    @ErrorCode400
+    @ErrorCode500
+    ResponseEntity<ResponseDto<VideoAnalysisResponse>> getVideoAnalysis(
+            @PathVariable String apiVideoId
+    );
+
+    @Operation(
+            summary = "전체 댓글 조회",
+            description = "영상의 전체 댓글 목록을 제공합니다.\n\n" +
+                    "**제공 정보:**\n" +
+                    "- 최대 100개 댓글 (관련도순)\n" +
+                    "- 댓글 내용, 작성자, 좋아요, 감정 분석 결과, 작성 시간\n\n" +
+                    "**특징:**\n" +
+                    "- 인증 불필요\n" +
+                    "- 페이징 없음 (한 번에 전체 반환)\n" +
+                    "- 클라이언트에서 검색/필터링 가능",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "전체 댓글 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseDto.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "timeStamp": "2025-01-20T10:00:02",
+                                                      "message": "전체 댓글 조회 성공",
+                                                      "data": [
+                                                        {
+                                                          "id": "comment1",
+                                                          "author": "사용자1",
+                                                          "text": "댓글 내용...",
+                                                          "likeCount": 150,
+                                                          "sentiment": "POSITIVE",
+                                                          "publishedAt": "2025-01-15T10:00:00Z"
+                                                        }
+                                                      ]
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    @Parameter(
+            name = "apiVideoId",
+            description = "YouTube 영상 ID",
+            required = true,
+            in = ParameterIn.PATH,
+            example = "dQw4w9WgXcQ"
+    )
+    @ErrorCode400
+    @ErrorCode500
+    ResponseEntity<ResponseDto<List<DetailCommentDto>>> getVideoComments(
+            @PathVariable String apiVideoId
+    );
+
+    @Operation(
+            summary = "AI 분석 결과 조회",
+            description = "FastAPI를 통해 분석된 AI 결과를 제공합니다.\n\n" +
+                    "**제공 정보:**\n" +
+                    "- AI 요약문\n" +
+                    "- 경고 여부\n" +
+                    "- 언어 분포 (한국어, 영어 등)\n" +
+                    "- 감정 분포 (긍정, 부정, 중립)\n" +
+                    "- 키워드 TOP 5\n\n" +
+                    "**특징:**\n" +
+                    "- 인증 불필요\n" +
+                    "- AI 미완료 시 빈 데이터 반환 (summary=null)\n" +
+                    "- 백그라운드 AI 처리 중일 수 있음 (Polling 권장)",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "AI 분석 결과 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseDto.class),
+                                    examples = {
+                                            @ExampleObject(
+                                                    name = "AI 분석 완료",
+                                                    value = """
+                                                            {
+                                                              "timeStamp": "2025-01-20T10:00:05",
+                                                              "message": "AI 분석 결과 조회 성공",
+                                                              "data": {
+                                                                "summary": "이 영상은 AI가 분석한 요약입니다...",
+                                                                "isWarning": false,
+                                                                "languageDistribution": [
+                                                                  {"language": "ko", "ratio": 0.85},
+                                                                  {"language": "en", "ratio": 0.15}
+                                                                ],
+                                                                "sentimentDistribution": {
+                                                                  "positive": 0.65,
+                                                                  "negative": 0.15,
+                                                                  "other": 0.20
+                                                                },
+                                                                "keywords": ["키워드1", "키워드2", "키워드3"]
+                                                              }
+                                                            }
+                                                            """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "AI 분석 미완료 (처리 중)",
+                                                    value = """
+                                                            {
+                                                              "timeStamp": "2025-01-20T10:00:03",
+                                                              "message": "AI 분석 결과 조회 성공",
+                                                              "data": {
+                                                                "summary": null,
+                                                                "isWarning": false,
+                                                                "languageDistribution": [],
+                                                                "sentimentDistribution": {
+                                                                  "positive": 0.0,
+                                                                  "negative": 0.0,
+                                                                  "other": 0.0
+                                                                },
+                                                                "keywords": []
+                                                              }
+                                                            }
+                                                            """
+                                            )
+                                    }
+                            )
+                    )
+            }
+    )
+    @Parameter(
+            name = "apiVideoId",
+            description = "YouTube 영상 ID",
+            required = true,
+            in = ParameterIn.PATH,
+            example = "dQw4w9WgXcQ"
+    )
+    @ErrorCode400
+    @ErrorCode500
+    ResponseEntity<ResponseDto<AIAnalysisResponse>> getAIAnalysis(
+            @PathVariable String apiVideoId
+    );
+}


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #106 
---
### 📌 요약
- 사용자 경험(UX) 개선 및 페이지 로딩 성능 최적화를 위해 Progressive Loading을 구현하도록 메인 페이지와 상세 페이지의 기존 통합 API를 여러 개의 독립적인 API로 분리했습니다.

### ✅ 작업 내용
- 메인 페이지를 3개의 엔드포인트로 분리
  - 관심 채널 목록 및 영상 요약
  - 인기 급상승 영상 목록
  - 사용자 스크랩 영상 목록
- 상세 페이지를 4개의 엔드포인트로 분리
  - 영상 및 채널 기본 정보
  - 백엔드 분석 정보
  - 영상 전체 댓글 목록
  - AI 분석 정보
- Swagger 문서 추가

### 📚 참고 자료, 할 말
- 없습니다.