### PR TITLE
[CHORE] 로컬 네트워크 IP CORS 허용 추가

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/global/security/SecurityConfig.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/security/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
                         "https://sosuso-client.vercel.app",
                         "https://*.vercel.app",
                         "http://localhost:8080",
-                        "https://knu-sosuso.com"
+                        "https://knu-sosuso.com",
+                        "http://10.2.*.*:3000"
                 ));
                 configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                 configuration.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #109
---
### 📌 요약
- 로컬 네트워크 환경(학교 Wi-Fi)에서 테스트가 가능하도록 CORS 허용 목록에 IP를 추가했습니다.

### ✅ 작업 내용
- `SecurityConfig`의 `CorsConfiguration`에 로컬 네트워크 IP를 추가했습니다.

### 📚 참고 자료, 할 말
- IP가 주기적으로 변경되기 때문에, 해당 설정도 주기적으로 업데이트할 예정입니다.