### PR TITLE
[FEATURE] 키워드 의미 검색 기능 구현

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/chatGPT/dto/Choice.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/chatGPT/dto/Choice.java
@@ -1,0 +1,13 @@
+package com.knu.sosuso.capstone.domain.keyword_search.chatGPT.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Choice {
+    private int index;
+    private Message message;
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/chatGPT/dto/Message.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/chatGPT/dto/Message.java
@@ -1,0 +1,13 @@
+package com.knu.sosuso.capstone.domain.keyword_search.chatGPT.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Message {
+    private String role;
+    private String content;
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/chatGPT/dto/request/ChatGPTRequest.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/chatGPT/dto/request/ChatGPTRequest.java
@@ -1,0 +1,22 @@
+package com.knu.sosuso.capstone.domain.keyword_search.chatGPT.dto.request;
+
+
+import com.knu.sosuso.capstone.domain.keyword_search.chatGPT.dto.Message;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatGPTRequest {
+
+    private final String model;
+    private final List<Message> messages;
+
+    public ChatGPTRequest(String model, String prompt) {
+        this.model = model;
+        this.messages = new ArrayList<>();
+        this.messages.add(new Message("user", prompt));
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/chatGPT/dto/response/ChatGPTResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/chatGPT/dto/response/ChatGPTResponse.java
@@ -1,0 +1,16 @@
+package com.knu.sosuso.capstone.domain.keyword_search.chatGPT.dto.response;
+
+import com.knu.sosuso.capstone.domain.keyword_search.chatGPT.dto.Choice;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatGPTResponse {
+    private List<Choice> choices;
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/chatGPT/service/OpenAIClient.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/chatGPT/service/OpenAIClient.java
@@ -1,0 +1,50 @@
+package com.knu.sosuso.capstone.domain.keyword_search.chatGPT.service;
+
+import com.knu.sosuso.capstone.domain.keyword_search.chatGPT.dto.request.ChatGPTRequest;
+import com.knu.sosuso.capstone.domain.keyword_search.chatGPT.dto.response.ChatGPTResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class OpenAIClient {
+
+    @Value("${openai.model}")
+    private String model;
+
+    @Value("${openai.api.url}")
+    private String apiURL;
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate;
+
+    public String chatCompletion(String prompt) {
+        ChatGPTRequest body = new ChatGPTRequest(model, prompt);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(apiKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+        HttpEntity<ChatGPTRequest> entity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<ChatGPTResponse> res =
+                restTemplate.exchange(apiURL, HttpMethod.POST, entity, ChatGPTResponse.class);
+
+        ChatGPTResponse data = res.getBody();
+        if (data == null || data.getChoices() == null || data.getChoices().isEmpty()) {
+            throw new IllegalStateException("OpenAI empty response");
+        }
+        return data.getChoices().get(0).getMessage().getContent();
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/controller/KeywordSearchController.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/controller/KeywordSearchController.java
@@ -1,0 +1,27 @@
+package com.knu.sosuso.capstone.domain.keyword_search.controller;
+
+import com.knu.sosuso.capstone.domain.keyword_search.dto.response.KeywordSearchResponse;
+import com.knu.sosuso.capstone.domain.keyword_search.service.KeywordSearchService;
+import com.knu.sosuso.capstone.global.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/keywords")
+@RestController
+public class KeywordSearchController {
+
+    private final KeywordSearchService keywordSearchService;
+
+    @GetMapping
+    private ResponseDto<KeywordSearchResponse> searchKeyword(
+            @RequestParam String query
+    ) {
+        String description = keywordSearchService.getKeywordDescription(query);
+        KeywordSearchResponse keywordSearchResponse = new KeywordSearchResponse(query, description);
+        return ResponseDto.of(keywordSearchResponse, "Successfully retrieved keyword meaning.");
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/dto/response/KeywordSearchResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/dto/response/KeywordSearchResponse.java
@@ -1,0 +1,7 @@
+package com.knu.sosuso.capstone.domain.keyword_search.dto.response;
+
+public record KeywordSearchResponse(
+        String query,
+        String description
+) {
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/service/KeywordSearchService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/keyword_search/service/KeywordSearchService.java
@@ -1,0 +1,31 @@
+package com.knu.sosuso.capstone.domain.keyword_search.service;
+
+import com.knu.sosuso.capstone.domain.keyword_search.chatGPT.service.OpenAIClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class KeywordSearchService {
+
+    private final OpenAIClient openAIClient;
+
+    public String getKeywordDescription(String keyword) {
+        String prompt = buildConversationalPrompt(keyword);
+        return openAIClient.chatCompletion(prompt);
+    }
+
+    private String buildConversationalPrompt(String keyword) {
+        return """
+                Explain the meaning of the following keyword in one concise Korean sentence.
+                The keyword may be in any language (Korean, English, Japanese, French, etc.).
+                Automatically detect its language, but always respond in Korean.
+                The explanation should be short, objective, and end with "이에요."
+                Do not include the keyword itself in the response.
+                If you are not certain about the meaning, consider if it might be a slang or new term,
+                and if still unsure, respond with "해당 단어의 정확한 의미를 알 수 없어요."
+                
+                Keyword: "%s"
+                """.formatted(keyword);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,9 @@ spring:
 youtube:
   api:
     key: ${YOUTUBE_API_KEY}
+
+openai:
+  model: ${OPENAI_MODEL}
+  api:
+    key: ${OPENAI_API_KEY}
+    url: ${OPENAI_API_URL}


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #123

---
### 📌 요약
- GPT 모델을 활용해 키워드의 의미를 한 줄로 요약해주는 기능을 구현했습니다.

### ✅ 작업 내용
- Chat Completions API 요청 및 응답 로직 추가
- 프롬프트 구조 정의: 문장은 항상 '~이에요.'로 끝나도록 구성
- 알 수 없는 단어에 대한 예외 응답 처리 ("해당 단어의 정확한 의미를 알 수 없어요.")

### 📚 참고 자료, 할 말
- 현재 모델: `gpt-4-nano` (Chat Completions 기반)
- 선택 이유: 응답 속도가 빠르고 비용 효율이 높아, 단일 문장 요약 기능에 적합하다고 판단해 해당 모델을 선택했습니다.
- 추후 필요 시 더 높은 reasoning 성능이 필요한 모델(`gpt-4o-mini`, `gpt-5-mini`)로 전환 예정입니다.