### PR TITLE
[FEATURE] 감정 세부 데이터 추가

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/ai/dto/AIAnalysisResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/ai/dto/AIAnalysisResponse.java
@@ -1,6 +1,6 @@
 package com.knu.sosuso.capstone.domain.ai.dto;
 
-import com.knu.sosuso.capstone.domain.comment.entity.value.SentimentType;
+import com.knu.sosuso.capstone.domain.comment.entity.value.CommentSentimentDetail;
 
 import java.util.List;
 import java.util.Map;
@@ -9,9 +9,9 @@ public record AIAnalysisResponse(
         Long videoId, // 영상 videoId
         String apiVideoId, // 영상 apiVideoId
         String summation, // 전체 댓글 요약
-        boolean isWarning,
+        boolean isWarning, // 논란 감지 유무
         List<String> keywords, // 댓글 주요 키워드
-        Map<String, SentimentType> sentimentComments, // 댓글별 긍정, 부정, 기타 (Map<apiCommentId, commentContent>)
+        List<CommentSentimentDetail> sentimentComments, //
         Map<String, Double> languageRatio, // 언어 비율
         Map<String, Double> sentimentRatio // 전체 댓글 긍정, 부정, 기타 비율
 ) {

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/Comment.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/Comment.java
@@ -4,6 +4,9 @@ import com.knu.sosuso.capstone.domain.video.entity.Video;
 import com.knu.sosuso.capstone.domain.comment.entity.value.SentimentType;
 import com.knu.sosuso.capstone.global.BaseEntity;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,9 +14,11 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Entity
-@Table(name = "comment")
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "comment")
+@Entity
 public class Comment extends BaseEntity {
 
     @JoinColumn(name = "video_id")
@@ -30,8 +35,11 @@ public class Comment extends BaseEntity {
     private Integer likeCount;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "sentiment_type", length = 255)
+    @Column(name = "sentiment_type")
     private SentimentType sentimentType;
+
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DetailSentiment> detailSentiments = new ArrayList<>();
 
     @Column(name = "writer")
     private String writer;
@@ -41,17 +49,4 @@ public class Comment extends BaseEntity {
 
     @Column(name = "has_replies")
     private Boolean hasReplies;
-
-    @Builder
-    public Comment(Video video, String apiCommentId, String commentContent,
-                   Integer likeCount, SentimentType sentimentType, String writer, String writtenAt, Boolean hasReplies) {
-        this.video = video;
-        this.apiCommentId = apiCommentId;
-        this.commentContent = commentContent;
-        this.likeCount = likeCount;
-        this.sentimentType = sentimentType;
-        this.writer = writer;
-        this.writtenAt = writtenAt;
-        this.hasReplies = hasReplies;
-    }
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/DetailSentiment.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/DetailSentiment.java
@@ -1,0 +1,33 @@
+package com.knu.sosuso.capstone.domain.comment.entity;
+
+import com.knu.sosuso.capstone.domain.comment.entity.value.DetailSentimentType;
+import com.knu.sosuso.capstone.global.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "detail_sentiment")
+@Entity
+public class DetailSentiment extends BaseEntity {
+
+    @JoinColumn(name = "comment_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Comment comment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "detail_sentiment")
+    private DetailSentimentType detailSentimentType;
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/value/CommentSentimentDetail.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/value/CommentSentimentDetail.java
@@ -1,0 +1,10 @@
+package com.knu.sosuso.capstone.domain.comment.entity.value;
+
+import java.util.List;
+
+public record CommentSentimentDetail(
+        String apiCommentId,
+        String content,
+        SentimentType sentimentType,
+        List<DetailSentimentType> detailSentimentTypes
+) {}

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/value/DetailSentimentType.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/value/DetailSentimentType.java
@@ -1,0 +1,10 @@
+package com.knu.sosuso.capstone.domain.comment.entity.value;
+
+public enum DetailSentimentType {
+    // positive
+    JOY, LOVE, GRATITUDE,
+    // negative
+    ANGER, SADNESS, FEAR,
+    // other
+    NEUTRAL
+}

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.knu.sosuso.capstone.domain.comment.repository;
 
 import com.knu.sosuso.capstone.domain.comment.entity.Comment;
 import com.knu.sosuso.capstone.domain.comment.entity.value.SentimentType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -39,5 +40,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByVideoIdOrderByLikeCountDesc(Long video_id);
 
+    Optional<Comment> findByApiCommentId(String apiCommentId);
 }
 

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/service/CommentMapper.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/service/CommentMapper.java
@@ -4,6 +4,7 @@ import com.knu.sosuso.capstone.domain.ai.dto.AIAnalysisResponse;
 import com.knu.sosuso.capstone.domain.comment.dto.CommentDto;
 import com.knu.sosuso.capstone.domain.comment.dto.response.CommentApiResponse;
 import com.knu.sosuso.capstone.domain.comment.entity.Comment;
+import com.knu.sosuso.capstone.domain.comment.entity.value.CommentSentimentDetail;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -64,10 +65,15 @@ public class CommentMapper {
             AIAnalysisResponse analysisResponse) {
 
         String sentiment = null;
-        if (analysisResponse != null &&
-                analysisResponse.sentimentComments().containsKey(commentData.id())) {
-            sentiment = analysisResponse.sentimentComments()
-                    .get(commentData.id()).name().toUpperCase();
+        if (analysisResponse != null) {
+            CommentSentimentDetail sentimentDetail = analysisResponse.sentimentComments().stream()
+                    .filter(detail -> detail.apiCommentId().equals(commentData.id()))
+                    .findFirst()
+                    .orElse(null);
+
+            if (sentimentDetail != null) {
+                sentiment = sentimentDetail.sentimentType().name().toUpperCase();
+            }
         }
 
         return new CommentDto(

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/service/CommentService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/service/CommentService.java
@@ -3,6 +3,9 @@ package com.knu.sosuso.capstone.domain.comment.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.knu.sosuso.capstone.domain.ai.dto.AIAnalysisResponse;
+import com.knu.sosuso.capstone.domain.comment.entity.DetailSentiment;
+import com.knu.sosuso.capstone.domain.comment.entity.value.CommentSentimentDetail;
+import com.knu.sosuso.capstone.domain.comment.entity.value.DetailSentimentType;
 import com.knu.sosuso.capstone.global.config.ApiConfig;
 import com.knu.sosuso.capstone.domain.comment.entity.Comment;
 import com.knu.sosuso.capstone.domain.video.entity.Video;
@@ -177,22 +180,40 @@ public class CommentService {
     }
 
     /**
-     * AI 분석 결과로 댓글 업데이트
+     * AI 분석 결과로 댓글 업데이트 (sentiment + detail sentiments)
      */
     @Transactional
     public void updateCommentsWithAnalysis(AIAnalysisResponse analysisResponse) {
         try {
-            List<Comment> comments = commentRepository.findAllByVideoId(analysisResponse.videoId());
+            // AI 분석 결과 순회
+            for (CommentSentimentDetail sentimentDetail : analysisResponse.sentimentComments()) {
+                // apiCommentId로 댓글 찾기
+                Comment comment = commentRepository.findByApiCommentId(sentimentDetail.apiCommentId())
+                        .orElse(null);
 
-            for (Comment comment : comments) {
-                if (analysisResponse.sentimentComments().containsKey(comment.getApiCommentId())) {
-                    comment.setSentimentType(analysisResponse.sentimentComments().get(comment.getApiCommentId()));
+                if (comment == null) {
+                    log.warn("댓글을 찾을 수 없음: apiCommentId={}", sentimentDetail.apiCommentId());
+                    continue;
                 }
+
+                // 1. 전체 감정 타입 업데이트
+                comment.setSentimentType(sentimentDetail.sentimentType());
+
+                // 2. 세부 감정 저장
+                for (DetailSentimentType detailType : sentimentDetail.detailSentimentTypes()) {
+                    DetailSentiment detailSentiment = DetailSentiment.builder()
+                            .comment(comment)
+                            .detailSentimentType(detailType)
+                            .build();
+                    comment.getDetailSentiments().add(detailSentiment);
+                }
+
+                commentRepository.save(comment);
             }
 
-            commentRepository.saveAll(comments);
             log.info("댓글 감정 분석 결과 업데이트 완료: videoId={}, 업데이트된 댓글 수={}",
-                    analysisResponse.videoId(), comments.size());
+                    analysisResponse.videoId(), analysisResponse.sentimentComments().size());
+
         } catch (Exception e) {
             log.error("댓글 감정 분석 업데이트 실패: videoId={}, error={}",
                     analysisResponse.videoId(), e.getMessage());

--- a/src/main/java/com/knu/sosuso/capstone/global/service/ResponseMappingService.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/service/ResponseMappingService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.knu.sosuso.capstone.domain.ai.dto.AIAnalysisResponse;
 import com.knu.sosuso.capstone.domain.comment.dto.CommentDto;
+import com.knu.sosuso.capstone.domain.comment.entity.value.CommentSentimentDetail;
 import com.knu.sosuso.capstone.domain.detail.dto.*;
 import com.knu.sosuso.capstone.domain.comment.dto.response.CommentApiResponse;
 import com.knu.sosuso.capstone.domain.comment.repository.CommentRepository;
@@ -347,9 +348,16 @@ public class ResponseMappingService {
     private CommentDto mapToCommentResponseWithAI(
             CommentApiResponse.CommentData commentData,
             AIAnalysisResponse analysisResponse) {
+
+        // List에서 해당 댓글의 감정 분석 결과 찾기
+        CommentSentimentDetail sentimentDetail = analysisResponse.sentimentComments().stream()
+                .filter(detail -> detail.apiCommentId().equals(commentData.id()))
+                .findFirst()
+                .orElse(null);
+
         String sentiment = null;
-        if (analysisResponse.sentimentComments().containsKey(commentData.id())) {
-            sentiment = analysisResponse.sentimentComments().get(commentData.id()).name().toUpperCase();
+        if (sentimentDetail != null) {
+            sentiment = sentimentDetail.sentimentType().name().toUpperCase();
         }
 
         return new CommentDto(
@@ -362,7 +370,6 @@ public class ResponseMappingService {
                 commentData.hasReplies()
         );
     }
-
     /**
      * AI 분석 결과가 없는 경우 댓글 변환
      */
@@ -391,8 +398,16 @@ public class ResponseMappingService {
                 .limit(5)
                 .map(commentData -> {
                     String sentiment = null;
-                    if (analysisResponse != null && analysisResponse.sentimentComments().containsKey(commentData.id())) {
-                        sentiment = analysisResponse.sentimentComments().get(commentData.id()).name().toUpperCase();
+                    if (analysisResponse != null) {
+                        // List에서 해당 댓글의 감정 분석 결과 찾기
+                        CommentSentimentDetail sentimentDetail = analysisResponse.sentimentComments().stream()
+                                .filter(detail -> detail.apiCommentId().equals(commentData.id()))
+                                .findFirst()
+                                .orElse(null);
+
+                        if (sentimentDetail != null) {
+                            sentiment = sentimentDetail.sentimentType().name().toUpperCase();
+                        }
                     }
 
                     // TOP 5 댓글은 hasReplies를 무조건 false로 설정


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #120

---

### 📌 요약
- 감정 세분화 데이터를 추가하고, 감정 세분화를 위한 새로운 테이블(`detail_sentiment`)을 생성했습니다.
- 이에 따라 기존 감정 분석 로직과 관련 엔티티 등을 리팩토링했습니다.

---

### ✅ 작업 내용
- `DetailSentimentType` enum 추가 (`JOY`, `LOVE`, `GRATITUDE`, `ANGER`, `SADNESS`, `FEAR`, `NEUTRAL`)
- 감정 세분화 테이블(Entity) 추가 및 매핑 구성

---

### 📚 참고 자료, 할 말
- ai 모델 개발 끝나면 연동할 예정입니당