### PR TITLE
[FEATURE] 댓글 감정 흐름 분석 기능 구현

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/repository/CommentRepository.java
@@ -41,5 +41,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByVideoIdOrderByLikeCountDesc(Long video_id);
 
     Optional<Comment> findByApiCommentId(String apiCommentId);
+
+    // 영상의 댓글을 작성 시간 순으로 조회 (오래된 순)
+    List<Comment> findByVideoIdOrderByWrittenAtAsc(Long videoId);
 }
 

--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/dto/DetailAnalysisDto.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/dto/DetailAnalysisDto.java
@@ -38,4 +38,12 @@ public record DetailAnalysisDto(
             Integer count
     ) {
     }
+
+    public record SentimentFlow(
+            String date,
+            Double positive,
+            Double negative,
+            Double other
+    ) {
+    }
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/dto/VideoAnalysisResponse.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/dto/VideoAnalysisResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record VideoAnalysisResponse(
         List<DetailAnalysisDto.CommentHistogram> commentHistogram,
         List<DetailAnalysisDto.PopularTimestamp> popularTimestamps,
-        List<CommentDto> topComments
+        List<CommentDto> topComments,
+        List<DetailAnalysisDto.SentimentFlow> sentimentFlow
 ) {
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
@@ -3,12 +3,15 @@ package com.knu.sosuso.capstone.domain.detail.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.knu.sosuso.capstone.domain.comment.dto.CommentDto;
+import com.knu.sosuso.capstone.domain.comment.entity.Comment;
+import com.knu.sosuso.capstone.domain.comment.entity.value.SentimentType;
 import com.knu.sosuso.capstone.domain.comment.repository.CommentRepository;
 import com.knu.sosuso.capstone.domain.detail.dto.*;
 import com.knu.sosuso.capstone.domain.video.entity.Video;
 import com.knu.sosuso.capstone.domain.video.repository.VideoRepository;
 import com.knu.sosuso.capstone.domain.video.service.UserDataService;
 import com.knu.sosuso.capstone.domain.video.service.VideoProcessingService;
+import com.knu.sosuso.capstone.global.config.AppConfig;
 import com.knu.sosuso.capstone.global.exception.BusinessException;
 import com.knu.sosuso.capstone.global.exception.error.CommonError;
 import com.knu.sosuso.capstone.global.exception.error.VideoError;
@@ -17,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +37,7 @@ public class VideoDetailService {
     private final UserDataService userDataService;
     private final VideoProcessingService videoProcessingService;
     private final ObjectMapper objectMapper;
+    private final AppConfig appConfig;
 
     /**
      * 영상 기본 정보 조회
@@ -85,7 +90,7 @@ public class VideoDetailService {
     }
 
     /**
-     * 영상 분석 정보 조회 (백엔드 분석 + TOP 5 댓글)
+     * 영상 분석 정보 조회 (백엔드 분석 + TOP 5 댓글 + 감정 흐름)
      * TOP 5 댓글은 hasReplies를 무조건 false로 설정
      */
     @Transactional(readOnly = true)
@@ -95,7 +100,7 @@ public class VideoDetailService {
         Video video = videoRepository.findByApiVideoId(apiVideoId)
                 .orElseThrow(() -> new BusinessException(VideoError.VIDEO_NOT_FOUND));
 
-        // 댓글 히스토그램
+        // 1. 댓글 히스토그램
         Map<Integer, Integer> commentHistogramData = parseJsonToMap(
                 video.getCommentHistogram(), Integer.class, Integer.class);
         List<DetailAnalysisDto.CommentHistogram> commentHistogram =
@@ -103,7 +108,7 @@ public class VideoDetailService {
                         .map(e -> new DetailAnalysisDto.CommentHistogram(String.valueOf(e.getKey()), e.getValue()))
                         .collect(Collectors.toList());
 
-        // 인기 타임스탬프
+        // 2. 인기 타임스탬프
         Map<String, Integer> popularTimestampsData = parseJsonToMap(
                 video.getPopularTimestamps(), String.class, Integer.class);
         List<DetailAnalysisDto.PopularTimestamp> popularTimestamps =
@@ -111,6 +116,7 @@ public class VideoDetailService {
                         .map(e -> new DetailAnalysisDto.PopularTimestamp(e.getKey(), e.getValue()))
                         .collect(Collectors.toList());
 
+        // 3. TOP 5 댓글
         List<CommentDto> topComments = commentRepository
                 .findByVideoIdOrderByLikeCountDesc(video.getId())
                 .stream()
@@ -126,8 +132,13 @@ public class VideoDetailService {
                 ))
                 .collect(Collectors.toList());
 
-        log.info("영상 분석 정보 조회 완료: apiVideoId={}, TOP 댓글 수={}", apiVideoId, topComments.size());
-        return new VideoAnalysisResponse(commentHistogram, popularTimestamps, topComments);
+        // 4. 감정 흐름 분석
+        List<DetailAnalysisDto.SentimentFlow> sentimentFlow = calculateSentimentFlow(video);
+
+        log.info("영상 분석 정보 조회 완료: apiVideoId={}, TOP 댓글 수={}, 감정 흐름 데이터={}개",
+                apiVideoId, topComments.size(), sentimentFlow.size());
+
+        return new VideoAnalysisResponse(commentHistogram, popularTimestamps, topComments, sentimentFlow);
     }
 
     /**
@@ -230,6 +241,166 @@ public class VideoDetailService {
     public DetailPageResponse getVideoDetail(String token, String apiVideoId) {
         log.warn("Deprecated 메서드 호출: getVideoDetail() - 분리된 메서드 사용 권장");
         return videoProcessingService.processVideoToSearchResult(token, apiVideoId, true);
+    }
+
+    // ==================== 감정 흐름 분석 ====================
+
+    /**
+     * 감정 흐름 데이터 계산 (최대 N개 데이터 포인트)
+     * 전체 기간을 균등하게 샘플링하여 대표값 추출
+     */
+    private List<DetailAnalysisDto.SentimentFlow> calculateSentimentFlow(Video video) {
+        try {
+            // 1. 댓글 조회 (작성 시간 순)
+            List<Comment> comments = commentRepository
+                    .findByVideoIdOrderByWrittenAtAsc(video.getId());
+
+            if (comments.isEmpty()) {
+                log.debug("댓글 없음, 빈 감정 흐름 반환: videoId={}", video.getId());
+                return new ArrayList<>();
+            }
+
+            // 2. 감정 타입이 있는 댓글 확인 (AI 분석 완료 여부)
+            long commentsWithSentiment = comments.stream()
+                    .filter(c -> c.getSentimentType() != null)
+                    .count();
+
+            if (commentsWithSentiment == 0) {
+                log.debug("AI 분석 미완료, 빈 감정 흐름 반환: videoId={}", video.getId());
+                return new ArrayList<>();
+            }
+
+            // 3. 날짜별로 댓글 그룹화
+            Map<LocalDate, List<Comment>> commentsByDate = comments.stream()
+                    .filter(c -> c.getSentimentType() != null)
+                    .collect(Collectors.groupingBy(comment ->
+                            parseCommentDate(comment.getWrittenAt())));
+
+            if (commentsByDate.isEmpty()) {
+                log.debug("날짜별 그룹화 실패, 빈 감정 흐름 반환: videoId={}", video.getId());
+                return new ArrayList<>();
+            }
+
+            // 4. 날짜 순으로 정렬
+            List<LocalDate> sortedDates = commentsByDate.keySet().stream()
+                    .sorted()
+                    .collect(Collectors.toList());
+
+            // 5. 각 날짜의 감정 분포 계산
+            List<DailySentimentData> allDailyData = sortedDates.stream()
+                    .map(date -> calculateDailySentiment(date, commentsByDate.get(date)))
+                    .collect(Collectors.toList());
+
+            // 6. 최대 N개로 샘플링
+            List<DetailAnalysisDto.SentimentFlow> sampledData =
+                    sampleSentimentData(allDailyData);
+
+            log.info("감정 흐름 계산 완료: videoId={}, 전체 {}일 → 샘플링 {}개",
+                    video.getId(), allDailyData.size(), sampledData.size());
+
+            return sampledData;
+
+        } catch (Exception e) {
+            log.warn("감정 흐름 계산 중 오류 발생, 빈 리스트 반환: videoId={}, error={}",
+                    video.getId(), e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * 하루치 감정 데이터 계산
+     */
+    private DailySentimentData calculateDailySentiment(LocalDate date, List<Comment> dayComments) {
+        long total = dayComments.size();
+        long positive = dayComments.stream()
+                .filter(c -> c.getSentimentType() == SentimentType.POSITIVE)
+                .count();
+        long negative = dayComments.stream()
+                .filter(c -> c.getSentimentType() == SentimentType.NEGATIVE)
+                .count();
+        long other = total - positive - negative;
+
+        return new DailySentimentData(
+                date,
+                total > 0 ? positive / (double) total : 0.0,
+                total > 0 ? negative / (double) total : 0.0,
+                total > 0 ? other / (double) total : 0.0
+        );
+    }
+
+    /**
+     * 감정 데이터를 최대 N개로 샘플링
+     * 전체 기간을 균등하게 나누어 대표값 선택
+     */
+    private List<DetailAnalysisDto.SentimentFlow> sampleSentimentData(
+            List<DailySentimentData> allData) {
+
+        int totalDays = allData.size();
+        int maxPoints = appConfig.getSentimentFlowMaxDataPoints();
+
+        // maxPoints 이하면 전체 반환
+        if (totalDays <= maxPoints) {
+            return allData.stream()
+                    .map(this::convertToSentimentFlow)
+                    .collect(Collectors.toList());
+        }
+
+        // maxPoints를 초과하면 균등 간격으로 샘플링
+        List<DetailAnalysisDto.SentimentFlow> result = new ArrayList<>();
+
+        // 첫 번째는 항상 포함
+        result.add(convertToSentimentFlow(allData.get(0)));
+
+        // 중간 포인트들을 균등 간격으로 선택
+        double step = (totalDays - 1) / (double) (maxPoints - 1);
+
+        for (int i = 1; i < maxPoints - 1; i++) {
+            int index = (int) Math.round(step * i);
+            result.add(convertToSentimentFlow(allData.get(index)));
+        }
+
+        // 마지막은 항상 포함
+        result.add(convertToSentimentFlow(allData.get(totalDays - 1)));
+
+        return result;
+    }
+
+    /**
+     * 내부 데이터를 응답 DTO로 변환
+     */
+    private DetailAnalysisDto.SentimentFlow convertToSentimentFlow(DailySentimentData data) {
+        return new DetailAnalysisDto.SentimentFlow(
+                data.date().toString(),
+                data.positive(),
+                data.negative(),
+                data.other()
+        );
+    }
+
+    /**
+     * 날짜 파싱 헬퍼 메서드
+     */
+    private LocalDate parseCommentDate(String writtenAt) {
+        try {
+            if (writtenAt == null || writtenAt.length() < 10) {
+                return LocalDate.now();
+            }
+            return LocalDate.parse(writtenAt.substring(0, 10));
+        } catch (Exception e) {
+            log.warn("댓글 날짜 파싱 실패: {}", writtenAt);
+            return LocalDate.now();
+        }
+    }
+
+    /**
+     * 내부 계산용 데이터 클래스
+     */
+    private record DailySentimentData(
+            LocalDate date,
+            Double positive,
+            Double negative,
+            Double other
+    ) {
     }
 
     // ==================== Helper Methods ====================

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoSearchService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoSearchService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -66,6 +67,27 @@ public class VideoSearchService {
             // 2. 검색 결과 파싱 및 DB 저장 (Fast Path)
             return processSearchResults(token, searchResponse, query, "VIDEO");
 
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode().value() == 403) {
+                String responseBody = e.getResponseBodyAsString();
+
+                if (responseBody.contains("quotaExceeded")) {
+                    log.error("YouTube API quota 초과: query={}", query);
+                    throw new BusinessException(SearchError.YOUTUBE_API_QUOTA_EXCEEDED);
+                }
+
+                if (responseBody.contains("IP address restriction")) {
+                    log.error("YouTube API IP 제한: query={}", query);
+                    throw new BusinessException(SearchError.YOUTUBE_API_ACCESS_DENIED);
+                }
+
+                log.error("YouTube API 403 에러: query={}, error={}", query, responseBody);
+                throw new BusinessException(SearchError.YOUTUBE_API_ACCESS_DENIED);
+            }
+
+            log.error("YouTube API 클라이언트 에러: query={}, status={}", query, e.getStatusCode());
+            throw new BusinessException(SearchError.YOUTUBE_API_ERROR);
+
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
@@ -97,6 +119,27 @@ public class VideoSearchService {
 
             // 2. 검색 결과 파싱 및 DB 저장 (Fast Path)
             return processSearchResults(token, searchResponse, query, "SHORT");
+
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode().value() == 403) {
+                String responseBody = e.getResponseBodyAsString();
+
+                if (responseBody.contains("quotaExceeded")) {
+                    log.error("YouTube API quota 초과: query={}", query);
+                    throw new BusinessException(SearchError.YOUTUBE_API_QUOTA_EXCEEDED);
+                }
+
+                if (responseBody.contains("IP address restriction")) {
+                    log.error("YouTube API IP 제한: query={}", query);
+                    throw new BusinessException(SearchError.YOUTUBE_API_ACCESS_DENIED);
+                }
+
+                log.error("YouTube API 403 에러: query={}, error={}", query, responseBody);
+                throw new BusinessException(SearchError.YOUTUBE_API_ACCESS_DENIED);
+            }
+
+            log.error("YouTube API 클라이언트 에러: query={}, status={}", query, e.getStatusCode());
+            throw new BusinessException(SearchError.YOUTUBE_API_ERROR);
 
         } catch (BusinessException e) {
             throw e;
@@ -149,9 +192,18 @@ public class VideoSearchService {
             String nextPageToken = rootNode.path("nextPageToken").asText(null);
 
             List<VideoSummaryResponse> results = new ArrayList<>();
+            int skippedCount = 0;
 
             if (itemsNode.isArray()) {
                 for (JsonNode item : itemsNode) {
+                    String kind = item.path("id").path("kind").asText();
+
+                    if (!"youtube#video".equals(kind)) {
+                        skippedCount++;
+                        log.debug("비디오가 아닌 항목 스킵: kind={}", kind);
+                        continue;
+                    }
+
                     String apiVideoId = item.path("id").path("videoId").asText();
 
                     if (apiVideoId == null || apiVideoId.isEmpty()) {
@@ -175,8 +227,8 @@ public class VideoSearchService {
 
             boolean hasMore = nextPageToken != null && !nextPageToken.isEmpty();
 
-            log.info("{} 검색 완료: query={}, 결과 수={}, hasMore={}",
-                    searchType, query, results.size(), hasMore);
+            log.info("{} 검색 완료: query={}, 전체={}, 비디오={}, 스킵={}, hasMore={}",
+                    searchType, query, itemsNode.size(), results.size(), skippedCount, hasMore);
 
             return new SearchResultPageResponse(
                     results,

--- a/src/main/java/com/knu/sosuso/capstone/global/config/AppConfig.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/config/AppConfig.java
@@ -75,13 +75,13 @@ public class AppConfig {
      * 검색 결과 페이지 당 개수
      * YouTube API 한 번 호출 시 가져올 결과 수
      */
-    private final int searchResultsPerPage = 5;
+    private final int searchResultsPerPage = 4;
 
     /**
      * 검색 결과 최대 페이지 수
      * 무한 스크롤 제한 (총 searchResultsPerPage * maxSearchPages 개)
      */
-    private final int maxSearchPages = 5;
+    private final int maxSearchPages = 10;
 
     // ========== 스레드풀 관련 설정 ==========
 

--- a/src/main/java/com/knu/sosuso/capstone/global/config/AppConfig.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/config/AppConfig.java
@@ -39,6 +39,12 @@ public class AppConfig {
      */
     private final int aiRetryCooldownMinutes = 5;
 
+    /**
+     * 감정 흐름 분석 최대 데이터 포인트 수
+     * 전체 기간을 이 개수로 샘플링
+     */
+    private final int sentimentFlowMaxDataPoints = 6;
+
     // ========== 인기도 계산 설정 ==========
 
     /**

--- a/src/main/java/com/knu/sosuso/capstone/global/exception/error/SearchError.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/exception/error/SearchError.java
@@ -8,7 +8,10 @@ public enum SearchError implements BaseError {
 
     SEARCH_QUERY_REQUIRED(HttpStatus.BAD_REQUEST, "검색어는 필수입니다."),
     SEARCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "검색 중 오류가 발생했습니다."),
-    INVALID_PAGE_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 페이지 토큰입니다.");
+    INVALID_PAGE_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 페이지 토큰입니다."),
+    YOUTUBE_API_QUOTA_EXCEEDED(HttpStatus.SERVICE_UNAVAILABLE, "일일 검색 한도를 초과했습니다. 내일 다시 이용해주세요."),
+    YOUTUBE_API_ACCESS_DENIED(HttpStatus.FORBIDDEN, "YouTube API 접근이 거부되었습니다."),
+    YOUTUBE_API_ERROR(HttpStatus.BAD_GATEWAY, "YouTube 서비스에 일시적인 문제가 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #125 
---
### 📌 요약
- 상세 페이지에 날짜별 댓글 감정 흐름 분석 기능을 추가했습니다. 시간에 따른 긍정/부정/기타 감정 변화를 최대 6개 포인트로 시각화할 수 있습니다.

### ✅ 작업 내용
- DTO 및 Repository 추가
- 감정 흐름 분석 로직 Service 구현
  - 첫 날과 마지막 날은 항상 포함
  - 중간 포인트는 균등 간격으로 선택
 - AI 분석 미완료 시 빈 배열 반환으로 처리

### 📚 참고 자료, 할 말
- AI 분석이 완료된 영상만 데이터 제공
- 댓글 없거나 AI 미완료 시 빈 배열 반환