### PR TITLE
[FIX] 엔티티 기본값 할당 및 Lombok 빌더 패턴 적용

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/channel/entity/FavoriteChannel.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/channel/entity/FavoriteChannel.java
@@ -3,11 +3,16 @@ package com.knu.sosuso.capstone.domain.channel.entity;
 import com.knu.sosuso.capstone.global.BaseEntity;
 import com.knu.sosuso.capstone.domain.auth.User;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Table(name = "favorite_channel")
 public class FavoriteChannel extends BaseEntity {
 
@@ -23,15 +28,4 @@ public class FavoriteChannel extends BaseEntity {
 
     @Column(name = "api_channel_thumbnail")
     private String apiChannelThumbnail;
-
-    protected FavoriteChannel() {
-    }
-
-    @Builder
-    public FavoriteChannel(User user, String apiChannelId, String apiChannelName, String apiChannelThumbnail) {
-        this.user = user;
-        this.apiChannelId = apiChannelId;
-        this.apiChannelName = apiChannelName;
-        this.apiChannelThumbnail = apiChannelThumbnail;
-    }
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/Comment.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/Comment.java
@@ -45,7 +45,7 @@ public class Comment extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "sentiment_type")
-    private SentimentType sentimentType;
+    private SentimentType sentimentType = SentimentType.OTHER;
 
     // JSON 컬럼으로 세부 감정 저장
     @Convert(converter = DetailSentimentListConverter.class)
@@ -60,5 +60,6 @@ public class Comment extends BaseEntity {
     private String writtenAt;
 
     @Column(name = "has_replies")
-    private Boolean hasReplies;
+    @Builder.Default
+    private Boolean hasReplies = false;
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/entity/Video.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/entity/Video.java
@@ -2,16 +2,15 @@ package com.knu.sosuso.capstone.domain.video.entity;
 
 import com.knu.sosuso.capstone.global.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @NoArgsConstructor
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @Entity
 @Table(name = "video")
 public class Video extends BaseEntity {
@@ -63,7 +62,8 @@ public class Video extends BaseEntity {
     private String summation;
 
     @Column(name = "warning")
-    private boolean isWarning;
+    @Builder.Default
+    private boolean isWarning = false;
 
     @Column(name = "language_distribution", columnDefinition = "JSON")
     private String languageDistribution;
@@ -79,15 +79,18 @@ public class Video extends BaseEntity {
 
     // 댓글 비활성화 여부 (YouTube에서 댓글 기능 꺼진 영상)
     @Column(name = "comments_disabled", nullable = false)
+    @Builder.Default
     private boolean commentsDisabled = false;
 
     // 댓글이 실제로 0개인지 여부 (비활성화는 아니지만 댓글 없음)
     @Column(name = "has_no_comments", nullable = false)
+    @Builder.Default
     private boolean hasNoComments = false;
 
     // AI 분석 상태 관리
     @Enumerated(EnumType.STRING)
     @Column(name = "ai_analysis_status", nullable = false)
+    @Builder.Default
     private AIAnalysisStatus aiAnalysisStatus = AIAnalysisStatus.PENDING;
 
     // 메타데이터(조회수, 좋아요 등) 마지막으로 갱신된 시간
@@ -96,6 +99,7 @@ public class Video extends BaseEntity {
 
     // YouTube에서 영상이 삭제되었는지 여부 (true: 삭제됨 또는 비공개 처리됨)
     @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
     private boolean deleted = false;
 
     // YouTube API로 삭제 여부를 마지막으로 확인한 시간
@@ -104,45 +108,6 @@ public class Video extends BaseEntity {
 
     // 메타데이터 업데이트 횟수 (통계용)
     @Column(name = "metadata_update_count", nullable = false)
+    @Builder.Default
     private int metadataUpdateCount = 0;
-
-    @Builder
-    public Video(String apiVideoId, VideoType videoType, String title, String description, String viewCount,
-                 String likeCount, String commentCount, String thumbnailUrl, String channelId,
-                 String channelName, String channelThumbnailUrl, String subscriberCount,
-                 String commentHistogram, String popularTimestamps, String summation,
-                 boolean isWarning, String languageDistribution, String sentimentDistribution,
-                 String keywords, String uploadedAt,
-                 boolean commentsDisabled, boolean hasNoComments,
-                 AIAnalysisStatus aiAnalysisStatus,
-                 LocalDateTime lastMetadataUpdatedAt, boolean deleted,
-                 LocalDateTime deleteCheckedAt, int metadataUpdateCount) {
-        this.apiVideoId = apiVideoId;
-        this.videoType = videoType;
-        this.title = title;
-        this.description = description;
-        this.viewCount = viewCount;
-        this.likeCount = likeCount;
-        this.commentCount = commentCount;
-        this.thumbnailUrl = thumbnailUrl;
-        this.channelId = channelId;
-        this.channelName = channelName;
-        this.channelThumbnailUrl = channelThumbnailUrl;
-        this.subscriberCount = subscriberCount;
-        this.commentHistogram = commentHistogram;
-        this.popularTimestamps = popularTimestamps;
-        this.summation = summation;
-        this.isWarning = isWarning;
-        this.languageDistribution = languageDistribution;
-        this.sentimentDistribution = sentimentDistribution;
-        this.keywords = keywords;
-        this.uploadedAt = uploadedAt;
-        this.commentsDisabled = commentsDisabled;
-        this.hasNoComments = hasNoComments;
-        this.aiAnalysisStatus = aiAnalysisStatus != null ? aiAnalysisStatus : AIAnalysisStatus.PENDING;
-        this.lastMetadataUpdatedAt = lastMetadataUpdatedAt;
-        this.deleted = deleted;
-        this.deleteCheckedAt = deleteCheckedAt;
-        this.metadataUpdateCount = metadataUpdateCount;
-    }
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/entity/VideoStats.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/entity/VideoStats.java
@@ -1,10 +1,7 @@
 package com.knu.sosuso.capstone.domain.video.entity;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -13,6 +10,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "video_stats")
 @NoArgsConstructor
+@AllArgsConstructor
 public class VideoStats {
 
     @Id
@@ -30,14 +28,4 @@ public class VideoStats {
 
     @Column(name = "last_calculated_at")
     private LocalDateTime lastCalculatedAt;
-
-    @Builder
-    public VideoStats(String apiVideoId, Integer viewCountRecent, Integer scrapCount,
-                      Double popularityScore, LocalDateTime lastCalculatedAt) {
-        this.apiVideoId = apiVideoId;
-        this.viewCountRecent = viewCountRecent;
-        this.scrapCount = scrapCount;
-        this.popularityScore = popularityScore;
-        this.lastCalculatedAt = lastCalculatedAt;
-    }
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/entity/VideoViewLog.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/entity/VideoViewLog.java
@@ -2,6 +2,7 @@ package com.knu.sosuso.capstone.domain.video.entity;
 
 import com.knu.sosuso.capstone.global.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +11,12 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
+@Builder
 @Table(name = "video_view_log", indexes = {
         @Index(name = "idx_api_video_id_viewed_at", columnList = "api_video_id, viewed_at")
 })
 @NoArgsConstructor
+@AllArgsConstructor
 public class VideoViewLog extends BaseEntity {
 
     @Column(name = "api_video_id", nullable = false)
@@ -24,11 +27,4 @@ public class VideoViewLog extends BaseEntity {
 
     @Column(name = "user_id")
     private Long userId;
-
-    @Builder
-    public VideoViewLog(String apiVideoId, LocalDateTime viewedAt, Long userId) {
-        this.apiVideoId = apiVideoId;
-        this.viewedAt = viewedAt;
-        this.userId = userId;
-    }
 }


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #134 
---
### 📌 요약
- DB 'cannot be null' 에러 및 NPE(NullPointerException)를 해결

### ✅ 작업 내용
- Comment, Video 엔티티의 null 가능 필드에 기본값을 할당하여
  DB 'cannot be null' 에러 및 NPE(NullPointerException)를 해결합니다.

- Video, Comment, FavoriteChannel, VideoViewLog 등
  주요 엔티티에 Lombok @Builder 및 @AllArgsConstructor를 추가하여 객체 생성 로직을 개선합니다.

### 📚 참고 자료, 할 말
- 없습니다.