### PR TITLE
fix: 감정 분포 파싱 키 대소문자 불일치 수정 #136

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
@@ -349,9 +349,9 @@ public class VideoDetailService {
                     new TypeReference<Map<String, Double>>() {});
 
             return new DetailAnalysisDto.SentimentDistribution(
-                    map.getOrDefault("POSITIVE", 0.0),
-                    map.getOrDefault("NEGATIVE", 0.0),
-                    map.getOrDefault("OTHER", 0.0)
+                    map.getOrDefault("positive", 0.0),
+                    map.getOrDefault("negative", 0.0),
+                    map.getOrDefault("other", 0.0)
             );
         } catch (Exception e) {
             log.warn("감정 분포 파싱 실패: {}", e.getMessage());
@@ -653,7 +653,7 @@ public class VideoDetailService {
                 comment.getWrittenAt(),
                 hasReplies,
                 detailSentiments
-                );
+        );
     }
 
     private boolean shouldCheckDeletion(Video video) {


### PR DESCRIPTION
- DB에 저장된 감정 분포 JSON 키가 소문자(positive, negative, other)인데 파싱 시 대문자(POSITIVE, NEGATIVE, OTHER)로 조회하여 항상 0.0이 반환되던 버그 수정

<!-- #이슈 번호를 매겨주세요 -->
- resolves #136 
---
### 📌 요약
- 감정 분포 응답 수정

### ✅ 작업 내용
- 응답 수정

### 📚 참고 자료, 할 말
- 실수로 커밋 태그 134로 했습니다. 136이 맞습니다..