### PR TITLE
[FIX] apiVideoId 컬럼에 unique 제약 추가

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/video/entity/Video.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/entity/Video.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @Table(name = "video")
 public class Video extends BaseEntity {
 
-    @Column(name = "api_video_id")
+    @Column(name = "api_video_id", unique = true)
     private String apiVideoId;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #153

---
### 📌 요약
- `video` 테이블 `api_video_id` 중복 저장 문제 해결
- UNIQUE 제약 추가 및 중복 데이터 정리
- 중복으로 인해 발생하던 `UnexpectedRollbackException` 근본 원인 제거

### ✅ 작업 내용
- `Video` 엔티티에 `@Column(unique = true)` 추가
- DB 레벨에서 `api_video_id` UNIQUE 제약 추가
- VideoSearchService에서 발생하던 "Query did not return a unique result" 문제 해결

### 📚 참고 자료, 할 말
- UNIQUE 제약이 없어서 동시성 상황에서 동일 `api_video_id`로 여러 row가 생성되었음  
- Spring Data JPA가 3개의 row를 조회하면서 예외 발생 → 트랜잭션 rollback → UnexpectedRollbackException  