### PR TITLE
[TEST] repository layer Test 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,11 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/knu/sosuso/capstone/domain/auth/User.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/auth/User.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Table(name = "user")
+@Table(name = "`user`")
 @Entity
 public class User extends BaseEntity {
 

--- a/src/main/java/com/knu/sosuso/capstone/domain/channel/service/FavoriteChannelService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/channel/service/FavoriteChannelService.java
@@ -149,7 +149,7 @@ public class FavoriteChannelService {
         String latestApiVideoId = channelService.getlatestApiVideoId(apiChannelId);
 
         // 2. 영상 처리 (DB에 저장/업데이트) - 반환값은 사용하지 않음
-        videoProcessingService.processVideoToSearchResult(token, latestApiVideoId, true);
+        videoProcessingService.processVideoToSearchResult(latestApiVideoId);
 
         Video video = videoRepository.findByApiVideoId(latestApiVideoId)
                 .orElseThrow(() -> new BusinessException(VideoError.VIDEO_NOT_FOUND));

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/repository/CommentRepository.java
@@ -17,9 +17,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 특정 비디오의 댓글들 조회 (Video 엔티티로)
     List<Comment> findByVideo(Video video);
 
-    // 특정 비디오의 댓글들 조회 (DB ID로)
-    List<Comment> findByVideoIdOrderByIdAsc(Long videoId);
-
     // 특정 비디오의 모든 댓글 조회 (DB ID로, 정렬 없음)
     List<Comment> findByVideoId(Long videoId);
 

--- a/src/main/java/com/knu/sosuso/capstone/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/scrap/repository/ScrapRepository.java
@@ -22,14 +22,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     List<Scrap> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     /**
-     * 특정 비디오의 모든 스크랩 삭제 (하드 삭제 시 사용)
-     * @return 삭제된 스크랩 개수
-     */
-    @Modifying
-    @Query("DELETE FROM Scrap s WHERE s.video.id = :videoId")
-    int deleteByVideoId(@Param("videoId") Long videoId);
-
-    /**
      * 영상별 스크랩 횟수 집계
      */
     @Query("""

--- a/src/main/java/com/knu/sosuso/capstone/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/scrap/repository/ScrapRepository.java
@@ -2,9 +2,7 @@ package com.knu.sosuso.capstone.domain.scrap.repository;
 
 import com.knu.sosuso.capstone.domain.scrap.entity.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/repository/VideoRepository.java
@@ -41,15 +41,4 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
      */
     List<Video> findTop10ByAiAnalysisStatusOrderByUpdatedAtDesc(AIAnalysisStatus status);
 
-    /**
-     * apiVideoId 목록으로 비디오 일괄 조회
-     * @param apiVideoIds 비디오 ID 목록
-     * @return 비디오 엔티티 목록
-     */
-    List<Video> findAllByApiVideoIdIn(List<String> apiVideoIds);
-
-    List<Video> findAllByApiVideoIdInAndVideoType(
-            List<String> apiVideoIds,
-            VideoType videoType
-    );
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/repository/VideoRepository.java
@@ -2,7 +2,6 @@ package com.knu.sosuso.capstone.domain.video.repository;
 
 import com.knu.sosuso.capstone.domain.video.entity.AIAnalysisStatus;
 import com.knu.sosuso.capstone.domain.video.entity.Video;
-import com.knu.sosuso.capstone.domain.video.entity.VideoType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoProcessingService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoProcessingService.java
@@ -19,7 +19,6 @@ import com.knu.sosuso.capstone.global.config.AppConfig;
 import com.knu.sosuso.capstone.global.exception.BusinessException;
 import com.knu.sosuso.capstone.global.exception.error.CommonError;
 import com.knu.sosuso.capstone.global.exception.error.VideoError;
-import com.knu.sosuso.capstone.global.service.mapper.ResponseMappingService;
 import com.knu.sosuso.capstone.global.service.mapper.VideoMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -138,8 +137,7 @@ public class VideoProcessingService {
      * 비디오 처리 메인 진입점 (검색용)
      */
     @Transactional
-    public Video processVideoToSearchResult(String token, String apiVideoId,
-                                            boolean enableAIAnalysis) {
+    public Video processVideoToSearchResult(String apiVideoId) {
         if (apiVideoId == null || apiVideoId.trim().isEmpty()) {
             throw new BusinessException(VideoError.VIDEO_ID_REQUIRED);
         }

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoService.java
@@ -32,10 +32,6 @@ public class VideoService {
     private static final String YOUTUBE_VIDEOS_API_URL = "https://www.googleapis.com/youtube/v3/videos";
     private static final String YOUTUBE_CHANNELS_API_URL = "https://www.googleapis.com/youtube/v3/channels";
 
-    private static final Pattern VIDEO_ID_PATTERN = Pattern.compile(
-            "(?:youtube\\.com/(?:watch\\?v=|embed/|v/)|youtu\\.be/|m\\.youtube\\.com/watch\\?v=)([\\w-]{11})"
-    );
-
     private final ApiConfig apiConfig;
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/com/knu/sosuso/capstone/domain/auth/UserRepositoryTest.java
+++ b/src/test/java/com/knu/sosuso/capstone/domain/auth/UserRepositoryTest.java
@@ -1,0 +1,134 @@
+package com.knu.sosuso.capstone.domain.auth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("UserRepository 통합 테스트")
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("findBySub 메서드는")
+    class FindBySubTest {
+
+        @Test
+        @DisplayName("sub로 사용자를 조회한다")
+        void findBySub_Exists_ReturnsUser() {
+            // given
+            User user = createUser("google-sub-123", "테스트유저");
+            userRepository.save(user);
+
+            // when
+            User found = userRepository.findBySub("google-sub-123");
+
+            // then
+            assertThat(found).isNotNull();
+            assertThat(found.getSub()).isEqualTo("google-sub-123");
+            assertThat(found.getName()).isEqualTo("테스트유저");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 sub면 null을 반환한다")
+        void findBySub_NotExists_ReturnsNull() {
+            // when
+            User found = userRepository.findBySub("not-exists");
+
+            // then
+            assertThat(found).isNull();
+        }
+
+        @Test
+        @DisplayName("여러 사용자 중 정확한 사용자를 조회한다")
+        void findBySub_MultipleUsers_ReturnsCorrectOne() {
+            // given
+            User user1 = createUser("sub-1", "유저1");
+            User user2 = createUser("sub-2", "유저2");
+            User user3 = createUser("sub-3", "유저3");
+            userRepository.save(user1);
+            userRepository.save(user2);
+            userRepository.save(user3);
+
+            // when
+            User found = userRepository.findBySub("sub-2");
+
+            // then
+            assertThat(found).isNotNull();
+            assertThat(found.getSub()).isEqualTo("sub-2");
+            assertThat(found.getName()).isEqualTo("유저2");
+        }
+    }
+
+    @Nested
+    @DisplayName("save 메서드는")
+    class SaveTest {
+
+        @Test
+        @DisplayName("새로운 사용자를 저장한다")
+        void save_NewUser_SavesSuccessfully() {
+            // given
+            User user = createUser("new-sub", "새로운유저");
+
+            // when
+            User saved = userRepository.save(user);
+
+            // then
+            assertThat(saved.getId()).isNotNull();
+            assertThat(saved.getSub()).isEqualTo("new-sub");
+        }
+
+        @Test
+        @DisplayName("사용자 정보를 업데이트한다")
+        void save_ExistingUser_UpdatesSuccessfully() {
+            // given
+            User user = createUser("test-sub", "원래이름");
+            User saved = userRepository.save(user);
+
+            // when
+            User found = userRepository.findBySub("test-sub");
+            // signIn 메서드로 정보 업데이트 (Google 로그인 시나리오)
+            com.knu.sosuso.capstone.global.security.GoogleUserInfo googleUserInfo =
+                    new com.knu.sosuso.capstone.global.security.GoogleUserInfo(
+                            "test-sub",
+                            "updated@example.com",
+                            "업데이트된이름",
+                            "ROLE_USER",
+                            "new-picture.jpg"
+                    );
+            found.signIn(googleUserInfo);
+            userRepository.save(found);
+
+            // then
+            User updated = userRepository.findBySub("test-sub");
+            assertThat(updated.getName()).isEqualTo("업데이트된이름");
+            assertThat(updated.getEmail()).isEqualTo("updated@example.com");
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    private User createUser(String sub, String name) {
+        return User.builder()
+                .sub(sub)
+                .email(sub + "@example.com")
+                .name(name)
+                .role("ROLE_USER")
+                .picture("https://example.com/picture.jpg")
+                .build();
+    }
+}

--- a/src/test/java/com/knu/sosuso/capstone/domain/channel/repository/FavoriteChannelRepositoryTest.java
+++ b/src/test/java/com/knu/sosuso/capstone/domain/channel/repository/FavoriteChannelRepositoryTest.java
@@ -1,0 +1,235 @@
+package com.knu.sosuso.capstone.domain.channel.repository;
+
+import com.knu.sosuso.capstone.domain.auth.User;
+import com.knu.sosuso.capstone.domain.auth.UserRepository;
+import com.knu.sosuso.capstone.domain.channel.entity.FavoriteChannel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("FavoriteChannelRepository 통합 테스트")
+class FavoriteChannelRepositoryTest {
+
+    @Autowired
+    private FavoriteChannelRepository favoriteChannelRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        favoriteChannelRepository.deleteAll();
+        userRepository.deleteAll();
+
+        testUser = createAndSaveUser("test-sub-123", "테스트유저");
+    }
+
+    @Nested
+    @DisplayName("existsByUserIdAndApiChannelId 메서드는")
+    class ExistsByUserIdAndApiChannelIdTest {
+
+        @Test
+        @DisplayName("사용자가 채널을 구독했으면 true를 반환한다")
+        void existsByUserAndChannel_Exists_ReturnsTrue() {
+            // given
+            FavoriteChannel favorite = createFavoriteChannel(testUser, "channel-123", "테스트채널");
+            favoriteChannelRepository.save(favorite);
+
+            // when
+            boolean exists = favoriteChannelRepository.existsByUserIdAndApiChannelId(
+                    testUser.getId(),
+                    "channel-123"
+            );
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("구독하지 않았으면 false를 반환한다")
+        void existsByUserAndChannel_NotExists_ReturnsFalse() {
+            // when
+            boolean exists = favoriteChannelRepository.existsByUserIdAndApiChannelId(
+                    testUser.getId(),
+                    "not-subscribed-channel"
+            );
+
+            // then
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUserIdAndApiChannelId 메서드는")
+    class FindByUserIdAndApiChannelIdTest {
+
+        @Test
+        @DisplayName("사용자의 관심 채널을 조회한다")
+        void findByUserAndChannel_Exists_ReturnsChannel() {
+            // given
+            FavoriteChannel favorite = createFavoriteChannel(testUser, "channel-123", "테스트채널");
+            favoriteChannelRepository.save(favorite);
+
+            // when
+            Optional<FavoriteChannel> found = favoriteChannelRepository.findByUserIdAndApiChannelId(
+                    testUser.getId(),
+                    "channel-123"
+            );
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getApiChannelId()).isEqualTo("channel-123");
+            assertThat(found.get().getApiChannelName()).isEqualTo("테스트채널");
+        }
+
+        @Test
+        @DisplayName("존재하지 않으면 빈 Optional을 반환한다")
+        void findByUserAndChannel_NotExists_ReturnsEmpty() {
+            // when
+            Optional<FavoriteChannel> found = favoriteChannelRepository.findByUserIdAndApiChannelId(
+                    testUser.getId(),
+                    "not-exists"
+            );
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUserId 메서드는")
+    class FindByUserIdTest {
+
+        @Test
+        @DisplayName("사용자의 모든 관심 채널을 조회한다")
+        void findByUserId_WithMultipleChannels_ReturnsAll() {
+            // given
+            FavoriteChannel channel1 = createFavoriteChannel(testUser, "channel-1", "채널1");
+            FavoriteChannel channel2 = createFavoriteChannel(testUser, "channel-2", "채널2");
+            FavoriteChannel channel3 = createFavoriteChannel(testUser, "channel-3", "채널3");
+            favoriteChannelRepository.saveAll(List.of(channel1, channel2, channel3));
+
+            // when
+            List<FavoriteChannel> found = favoriteChannelRepository.findByUserId(testUser.getId());
+
+            // then
+            assertThat(found).hasSize(3);
+            assertThat(found).extracting(FavoriteChannel::getApiChannelId)
+                    .containsExactlyInAnyOrder("channel-1", "channel-2", "channel-3");
+        }
+
+        @Test
+        @DisplayName("관심 채널이 없으면 빈 리스트를 반환한다")
+        void findByUserId_NoChannels_ReturnsEmpty() {
+            // when
+            List<FavoriteChannel> found = favoriteChannelRepository.findByUserId(testUser.getId());
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 관심 채널은 조회되지 않는다")
+        void findByUserId_OtherUserChannels_NotIncluded() {
+            // given
+            User otherUser = createAndSaveUser("other-sub", "다른유저");
+            FavoriteChannel otherFavorite = createFavoriteChannel(otherUser, "channel-999", "다른채널");
+            favoriteChannelRepository.save(otherFavorite);
+
+            // when
+            List<FavoriteChannel> found = favoriteChannelRepository.findByUserId(testUser.getId());
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdAndUserId 메서드는")
+    class FindByIdAndUserIdTest {
+
+        @Test
+        @DisplayName("ID와 사용자 ID로 관심 채널을 조회한다")
+        void findByIdAndUserId_Exists_ReturnsChannel() {
+            // given
+            FavoriteChannel favorite = createFavoriteChannel(testUser, "channel-123", "테스트채널");
+            FavoriteChannel saved = favoriteChannelRepository.save(favorite);
+
+            // when
+            Optional<FavoriteChannel> found = favoriteChannelRepository.findByIdAndUserId(
+                    saved.getId(),
+                    testUser.getId()
+            );
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getId()).isEqualTo(saved.getId());
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 채널은 조회되지 않는다")
+        void findByIdAndUserId_OtherUser_ReturnsEmpty() {
+            // given
+            User otherUser = createAndSaveUser("other-sub", "다른유저");
+            FavoriteChannel otherFavorite = createFavoriteChannel(otherUser, "channel-999", "다른채널");
+            FavoriteChannel saved = favoriteChannelRepository.save(otherFavorite);
+
+            // when
+            Optional<FavoriteChannel> found = favoriteChannelRepository.findByIdAndUserId(
+                    saved.getId(),
+                    testUser.getId()
+            );
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID면 빈 Optional을 반환한다")
+        void findByIdAndUserId_NotExists_ReturnsEmpty() {
+            // when
+            Optional<FavoriteChannel> found = favoriteChannelRepository.findByIdAndUserId(
+                    999L,
+                    testUser.getId()
+            );
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    private User createAndSaveUser(String sub, String name) {
+        User user = User.builder()
+                .sub(sub)
+                .email(sub + "@example.com")
+                .name(name)
+                .role("ROLE_USER")
+                .picture("https://example.com/picture.jpg")
+                .build();
+        return userRepository.save(user);
+    }
+
+    private FavoriteChannel createFavoriteChannel(User user, String channelId, String channelName) {
+        return FavoriteChannel.builder()
+                .user(user)
+                .apiChannelId(channelId)
+                .apiChannelName(channelName)
+                .apiChannelThumbnail("https://example.com/channel.jpg")
+                .build();
+    }
+}

--- a/src/test/java/com/knu/sosuso/capstone/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/knu/sosuso/capstone/domain/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,530 @@
+package com.knu.sosuso.capstone.domain.comment.repository;
+
+import com.knu.sosuso.capstone.domain.comment.entity.Comment;
+import com.knu.sosuso.capstone.domain.comment.entity.value.DetailSentimentType;
+import com.knu.sosuso.capstone.domain.comment.entity.value.SentimentType;
+import com.knu.sosuso.capstone.domain.video.entity.AIAnalysisStatus;
+import com.knu.sosuso.capstone.domain.video.entity.Video;
+import com.knu.sosuso.capstone.domain.video.entity.VideoType;
+import com.knu.sosuso.capstone.domain.video.repository.VideoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("CommentRepository 통합 테스트")
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private VideoRepository videoRepository;
+
+    private Video testVideo;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository.deleteAll();
+        videoRepository.deleteAll();
+
+        testVideo = createAndSaveVideo("test-video-123", "테스트 영상");
+    }
+
+    @Nested
+    @DisplayName("findByVideo 메서드는")
+    class FindByVideoTest {
+
+        @Test
+        @DisplayName("특정 비디오의 모든 댓글을 조회한다")
+        void findByVideo_WithComments_ReturnsAll() {
+            // given
+            Comment comment1 = createComment(testVideo, "api-1", "댓글1");
+            Comment comment2 = createComment(testVideo, "api-2", "댓글2");
+            Comment comment3 = createComment(testVideo, "api-3", "댓글3");
+            commentRepository.saveAll(List.of(comment1, comment2, comment3));
+
+            // when
+            List<Comment> found = commentRepository.findByVideo(testVideo);
+
+            // then
+            assertThat(found).hasSize(3);
+            assertThat(found).extracting(Comment::getApiCommentId)
+                    .containsExactlyInAnyOrder("api-1", "api-2", "api-3");
+        }
+
+        @Test
+        @DisplayName("댓글이 없으면 빈 리스트를 반환한다")
+        void findByVideo_NoComments_ReturnsEmpty() {
+            // when
+            List<Comment> found = commentRepository.findByVideo(testVideo);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 비디오의 댓글은 조회되지 않는다")
+        void findByVideo_OtherVideo_NotIncluded() {
+            // given
+            Video otherVideo = createAndSaveVideo("other-video", "다른 영상");
+            Comment otherComment = createComment(otherVideo, "other-api", "다른 댓글");
+            commentRepository.save(otherComment);
+
+            // when
+            List<Comment> found = commentRepository.findByVideo(testVideo);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByVideoId 메서드는")
+    class FindByVideoIdTest {
+
+        @Test
+        @DisplayName("비디오 ID로 댓글을 조회한다")
+        void findByVideoId_WithComments_ReturnsAll() {
+            // given
+            Comment comment1 = createComment(testVideo, "api-1", "댓글1");
+            Comment comment2 = createComment(testVideo, "api-2", "댓글2");
+            commentRepository.saveAll(List.of(comment1, comment2));
+
+            // when
+            List<Comment> found = commentRepository.findByVideoId(testVideo.getId());
+
+            // then
+            assertThat(found).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("댓글이 없으면 빈 리스트를 반환한다")
+        void findByVideoId_NoComments_ReturnsEmpty() {
+            // when
+            List<Comment> found = commentRepository.findByVideoId(testVideo.getId());
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByApiCommentId 메서드는")
+    class ExistsByApiCommentIdTest {
+
+        @Test
+        @DisplayName("이미 존재하는 댓글이면 true를 반환한다")
+        void existsByApiCommentId_Exists_ReturnsTrue() {
+            // given
+            Comment comment = createComment(testVideo, "exists-123", "존재하는 댓글");
+            commentRepository.save(comment);
+
+            // when
+            boolean exists = commentRepository.existsByApiCommentId("exists-123");
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 댓글이면 false를 반환한다")
+        void existsByApiCommentId_NotExists_ReturnsFalse() {
+            // when
+            boolean exists = commentRepository.existsByApiCommentId("not-exists");
+
+            // then
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByApiCommentId 메서드는")
+    class FindByApiCommentIdTest {
+
+        @Test
+        @DisplayName("API 댓글 ID로 댓글을 조회한다")
+        void findByApiCommentId_Exists_ReturnsComment() {
+            // given
+            Comment comment = createComment(testVideo, "api-123", "테스트 댓글");
+            commentRepository.save(comment);
+
+            // when
+            Optional<Comment> found = commentRepository.findByApiCommentId("api-123");
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getCommentContent()).isEqualTo("테스트 댓글");
+        }
+
+        @Test
+        @DisplayName("존재하지 않으면 빈 Optional을 반환한다")
+        void findByApiCommentId_NotExists_ReturnsEmpty() {
+            // when
+            Optional<Comment> found = commentRepository.findByApiCommentId("not-exists");
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByVideoIdAndTextContaining 메서드는")
+    class FindByVideoIdAndTextContainingTest {
+
+        @Test
+        @DisplayName("텍스트를 포함하는 댓글을 검색한다")
+        void findByText_WithMatchingComments_ReturnsMatched() {
+            // given
+            Comment comment1 = createComment(testVideo, "api-1", "이 영상 정말 재미있어요");
+            Comment comment2 = createComment(testVideo, "api-2", "재미있는 내용이네요");
+            Comment comment3 = createComment(testVideo, "api-3", "그냥 그래요");
+            commentRepository.saveAll(List.of(comment1, comment2, comment3));
+
+            // when
+            List<Comment> found = commentRepository.findByVideoIdAndTextContaining(
+                    testVideo.getId(), "재미있"
+            );
+
+            // then
+            assertThat(found).hasSize(2);
+            assertThat(found).extracting(Comment::getCommentContent)
+                    .allMatch(content -> content.contains("재미있"));
+        }
+
+        @Test
+        @DisplayName("대소문자 구분 없이 검색한다")
+        void findByText_CaseInsensitive_ReturnsMatched() {
+            // given
+            Comment comment = createComment(testVideo, "api-1", "GOOD VIDEO");
+            commentRepository.save(comment);
+
+            // when
+            List<Comment> found = commentRepository.findByVideoIdAndTextContaining(
+                    testVideo.getId(), "good"
+            );
+
+            // then
+            assertThat(found).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("매칭되는 댓글이 없으면 빈 리스트를 반환한다")
+        void findByText_NoMatch_ReturnsEmpty() {
+            // given
+            Comment comment = createComment(testVideo, "api-1", "평범한 댓글");
+            commentRepository.save(comment);
+
+            // when
+            List<Comment> found = commentRepository.findByVideoIdAndTextContaining(
+                    testVideo.getId(), "재미있"
+            );
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("부분 문자열도 검색된다")
+        void findByText_PartialMatch_ReturnsMatched() {
+            // given
+            Comment comment = createComment(testVideo, "api-1", "대한민국 화이팅");
+            commentRepository.save(comment);
+
+            // when
+            List<Comment> found = commentRepository.findByVideoIdAndTextContaining(
+                    testVideo.getId(), "민국"
+            );
+
+            // then
+            assertThat(found).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByVideoIdAndSentimentTypeOrderById 메서드는")
+    class FindByVideoIdAndSentimentTypeTest {
+
+        @Test
+        @DisplayName("특정 감정 타입의 댓글만 조회한다")
+        void findBySentimentType_Positive_ReturnsOnlyPositive() {
+            // given
+            Comment positive1 = createComment(testVideo, "api-1", "좋아요", SentimentType.POSITIVE);
+            Comment positive2 = createComment(testVideo, "api-2", "최고예요", SentimentType.POSITIVE);
+            Comment negative = createComment(testVideo, "api-3", "별로예요", SentimentType.NEGATIVE);
+            commentRepository.saveAll(List.of(positive1, positive2, negative));
+
+            // when
+            List<Comment> found = commentRepository.findByVideoIdAndSentimentTypeOrderById(
+                    testVideo.getId(), SentimentType.POSITIVE
+            );
+
+            // then
+            assertThat(found).hasSize(2);
+            assertThat(found).allMatch(c -> c.getSentimentType() == SentimentType.POSITIVE);
+        }
+
+        @Test
+        @DisplayName("NEGATIVE 감정만 필터링한다")
+        void findBySentimentType_Negative_ReturnsOnlyNegative() {
+            // given
+            Comment positive = createComment(testVideo, "api-1", "좋아요", SentimentType.POSITIVE);
+            Comment negative = createComment(testVideo, "api-2", "싫어요", SentimentType.NEGATIVE);
+            commentRepository.saveAll(List.of(positive, negative));
+
+            // when
+            List<Comment> found = commentRepository.findByVideoIdAndSentimentTypeOrderById(
+                    testVideo.getId(), SentimentType.NEGATIVE
+            );
+
+            // then
+            assertThat(found).hasSize(1);
+            assertThat(found.get(0).getSentimentType()).isEqualTo(SentimentType.NEGATIVE);
+        }
+
+        @Test
+        @DisplayName("ID 순으로 정렬된다")
+        void findBySentimentType_OrderById_ReturnsSorted() {
+            // given
+            for (int i = 5; i >= 1; i--) {
+                Comment comment = createComment(testVideo, "api-" + i, "댓글" + i, SentimentType.POSITIVE);
+                commentRepository.save(comment);
+            }
+
+            // when
+            List<Comment> found = commentRepository.findByVideoIdAndSentimentTypeOrderById(
+                    testVideo.getId(), SentimentType.POSITIVE
+            );
+
+            // then
+            assertThat(found).hasSize(5);
+            // ID가 오름차순인지 확인
+            for (int i = 0; i < found.size() - 1; i++) {
+                assertThat(found.get(i).getId()).isLessThan(found.get(i + 1).getId());
+            }
+        }
+
+        @Test
+        @DisplayName("OTHER 타입도 조회된다")
+        void findBySentimentType_Other_ReturnsOther() {
+            // given
+            Comment other = createComment(testVideo, "api-1", "그냥그래요", SentimentType.OTHER);
+            commentRepository.save(other);
+
+            // when
+            List<Comment> found = commentRepository.findByVideoIdAndSentimentTypeOrderById(
+                    testVideo.getId(), SentimentType.OTHER
+            );
+
+            // then
+            assertThat(found).hasSize(1);
+            assertThat(found.get(0).getSentimentType()).isEqualTo(SentimentType.OTHER);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByVideoIdOrderByLikeCountDesc 메서드는")
+    class FindByVideoIdOrderByLikeCountDescTest {
+
+        @Test
+        @DisplayName("좋아요 수 내림차순으로 정렬한다")
+        void orderByLikeCount_Desc_ReturnsSorted() {
+            // given
+            Comment comment1 = createComment(testVideo, "api-1", "댓글1");
+            comment1.setLikeCount(100);
+
+            Comment comment2 = createComment(testVideo, "api-2", "댓글2");
+            comment2.setLikeCount(500);
+
+            Comment comment3 = createComment(testVideo, "api-3", "댓글3");
+            comment3.setLikeCount(200);
+
+            commentRepository.saveAll(List.of(comment1, comment2, comment3));
+
+            // when
+            List<Comment> found = commentRepository.findByVideoIdOrderByLikeCountDesc(
+                    testVideo.getId()
+            );
+
+            // then
+            assertThat(found).hasSize(3);
+            assertThat(found.get(0).getLikeCount()).isEqualTo(500);
+            assertThat(found.get(1).getLikeCount()).isEqualTo(200);
+            assertThat(found.get(2).getLikeCount()).isEqualTo(100);
+        }
+
+        @Test
+        @DisplayName("좋아요 수가 같으면 순서가 보장되지 않는다")
+        void orderByLikeCount_SameCount_AnyOrder() {
+            // given
+            Comment comment1 = createComment(testVideo, "api-1", "댓글1");
+            comment1.setLikeCount(100);
+
+            Comment comment2 = createComment(testVideo, "api-2", "댓글2");
+            comment2.setLikeCount(100);
+
+            commentRepository.saveAll(List.of(comment1, comment2));
+
+            // when
+            List<Comment> found = commentRepository.findByVideoIdOrderByLikeCountDesc(
+                    testVideo.getId()
+            );
+
+            // then
+            assertThat(found).hasSize(2);
+            assertThat(found).allMatch(c -> c.getLikeCount() == 100);
+        }
+    }
+
+    @Nested
+    @DisplayName("findTop5ByVideoIdOrderByLikeCountDesc 메서드는")
+    class FindTop5ByVideoIdTest {
+
+        @Test
+        @DisplayName("좋아요 순 상위 5개만 조회한다")
+        void findTop5_WithMore_ReturnsTop5() {
+            // given
+            for (int i = 1; i <= 10; i++) {
+                Comment comment = createComment(testVideo, "api-" + i, "댓글" + i);
+                comment.setLikeCount(i * 10);
+                commentRepository.save(comment);
+            }
+
+            // when
+            List<Comment> found = commentRepository.findTop5ByVideoIdOrderByLikeCountDesc(
+                    testVideo.getId()
+            );
+
+            // then
+            assertThat(found).hasSize(5);
+            assertThat(found.get(0).getLikeCount()).isEqualTo(100);
+            assertThat(found.get(4).getLikeCount()).isEqualTo(60);
+        }
+
+        @Test
+        @DisplayName("댓글이 5개 미만이면 있는 만큼만 반환한다")
+        void findTop5_LessThan5_ReturnsAll() {
+            // given
+            for (int i = 1; i <= 3; i++) {
+                Comment comment = createComment(testVideo, "api-" + i, "댓글" + i);
+                comment.setLikeCount(i * 10);
+                commentRepository.save(comment);
+            }
+
+            // when
+            List<Comment> found = commentRepository.findTop5ByVideoIdOrderByLikeCountDesc(
+                    testVideo.getId()
+            );
+
+            // then
+            assertThat(found).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("댓글이 없으면 빈 리스트를 반환한다")
+        void findTop5_NoComments_ReturnsEmpty() {
+            // when
+            List<Comment> found = commentRepository.findTop5ByVideoIdOrderByLikeCountDesc(
+                    testVideo.getId()
+            );
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteByVideoId 메서드는")
+    class DeleteByVideoIdTest {
+
+        @Test
+        @DisplayName("특정 비디오의 모든 댓글을 삭제한다")
+        void deleteByVideoId_WithComments_DeletesAll() {
+            // given
+            Comment comment1 = createComment(testVideo, "api-1", "댓글1");
+            Comment comment2 = createComment(testVideo, "api-2", "댓글2");
+            commentRepository.saveAll(List.of(comment1, comment2));
+
+            // when
+            commentRepository.deleteByVideoId(testVideo.getId());
+            commentRepository.flush();
+
+            // then
+            List<Comment> found = commentRepository.findByVideoId(testVideo.getId());
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 비디오의 댓글은 삭제되지 않는다")
+        void deleteByVideoId_OtherVideo_NotDeleted() {
+            // given
+            Video otherVideo = createAndSaveVideo("other-video", "다른 영상");
+            Comment myComment = createComment(testVideo, "api-1", "내 댓글");
+            Comment otherComment = createComment(otherVideo, "api-2", "다른 댓글");
+            commentRepository.saveAll(List.of(myComment, otherComment));
+
+            // when
+            commentRepository.deleteByVideoId(testVideo.getId());
+            commentRepository.flush();
+
+            // then
+            List<Comment> remainingComments = commentRepository.findByVideoId(otherVideo.getId());
+            assertThat(remainingComments).hasSize(1);
+            assertThat(remainingComments.get(0).getApiCommentId()).isEqualTo("api-2");
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    private Video createAndSaveVideo(String apiVideoId, String title) {
+        Video video = Video.builder()
+                .apiVideoId(apiVideoId)
+                .title(title)
+                .description("테스트 설명")
+                .videoType(VideoType.VIDEO)
+                .viewCount("1000")
+                .likeCount("100")
+                .commentCount("50")
+                .thumbnailUrl("https://example.com/thumb.jpg")
+                .channelId("channel-123")
+                .channelName("테스트 채널")
+                .channelThumbnailUrl("https://example.com/channel.jpg")
+                .subscriberCount("10000")
+                .uploadedAt("2024-01-01T00:00:00Z")
+                .commentHistogram("{}")
+                .popularTimestamps("{}")
+                .aiAnalysisStatus(AIAnalysisStatus.PENDING)
+                .lastMetadataUpdatedAt(LocalDateTime.now())
+                .build();
+        return videoRepository.save(video);
+    }
+
+    private Comment createComment(Video video, String apiCommentId, String content) {
+        return createComment(video, apiCommentId, content, SentimentType.OTHER);
+    }
+
+    private Comment createComment(Video video, String apiCommentId, String content, SentimentType sentimentType) {
+        return Comment.builder()
+                .video(video)
+                .apiCommentId(apiCommentId)
+                .commentContent(content)
+                .likeCount(0)
+                .sentimentType(sentimentType)
+                .detailSentiments(List.of(DetailSentimentType.NEUTRAL))
+                .writer("테스트 작성자")
+                .writtenAt("2024-01-01T00:00:00Z")
+                .hasReplies(false)
+                .build();
+    }
+}

--- a/src/test/java/com/knu/sosuso/capstone/domain/scrap/repository/ScrapRepositoryTest.java
+++ b/src/test/java/com/knu/sosuso/capstone/domain/scrap/repository/ScrapRepositoryTest.java
@@ -1,0 +1,446 @@
+package com.knu.sosuso.capstone.domain.scrap.repository;
+
+import com.knu.sosuso.capstone.domain.auth.User;
+import com.knu.sosuso.capstone.domain.auth.UserRepository;
+import com.knu.sosuso.capstone.domain.scrap.entity.Scrap;
+import com.knu.sosuso.capstone.domain.video.entity.AIAnalysisStatus;
+import com.knu.sosuso.capstone.domain.video.entity.Video;
+import com.knu.sosuso.capstone.domain.video.entity.VideoType;
+import com.knu.sosuso.capstone.domain.video.repository.VideoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("ScrapRepository 통합 테스트")
+class ScrapRepositoryTest {
+
+    @Autowired
+    private ScrapRepository scrapRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private VideoRepository videoRepository;
+
+    private User testUser;
+    private Video testVideo;
+
+    @BeforeEach
+    void setUp() {
+        scrapRepository.deleteAll();
+        videoRepository.deleteAll();
+        userRepository.deleteAll();
+
+        testUser = createAndSaveUser("test-sub-123", "테스트유저");
+        testVideo = createAndSaveVideo("test-video-123", "테스트영상");
+    }
+
+    @Nested
+    @DisplayName("existsByVideoId 메서드는")
+    class ExistsByVideoIdTest {
+
+        @Test
+        @DisplayName("스크랩이 존재하면 true를 반환한다")
+        void existsByVideoId_Exists_ReturnsTrue() {
+            // given
+            Scrap scrap = createScrap(testUser, testVideo);
+            scrapRepository.save(scrap);
+
+            // when
+            boolean exists = scrapRepository.existsByVideoId(testVideo.getId());
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("스크랩이 없으면 false를 반환한다")
+        void existsByVideoId_NotExists_ReturnsFalse() {
+            // when
+            boolean exists = scrapRepository.existsByVideoId(999L);
+
+            // then
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        @DisplayName("여러 사용자가 스크랩해도 true를 반환한다")
+        void existsByVideoId_MultipleUsers_ReturnsTrue() {
+            // given
+            User user1 = createAndSaveUser("user1", "유저1");
+            User user2 = createAndSaveUser("user2", "유저2");
+
+            scrapRepository.save(createScrap(user1, testVideo));
+            scrapRepository.save(createScrap(user2, testVideo));
+
+            // when
+            boolean exists = scrapRepository.existsByVideoId(testVideo.getId());
+
+            // then
+            assertThat(exists).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByUserIdAndApiVideoId 메서드는")
+    class ExistsByUserIdAndApiVideoIdTest {
+
+        @Test
+        @DisplayName("사용자가 해당 영상을 스크랩했으면 true를 반환한다")
+        void existsByUserAndVideo_Exists_ReturnsTrue() {
+            // given
+            Scrap scrap = createScrap(testUser, testVideo);
+            scrapRepository.save(scrap);
+
+            // when
+            boolean exists = scrapRepository.existsByUserIdAndApiVideoId(
+                    testUser.getId(),
+                    testVideo.getApiVideoId()
+            );
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("스크랩하지 않았으면 false를 반환한다")
+        void existsByUserAndVideo_NotExists_ReturnsFalse() {
+            // when
+            boolean exists = scrapRepository.existsByUserIdAndApiVideoId(
+                    testUser.getId(),
+                    "not-scraped-video"
+            );
+
+            // then
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 스크랩은 false를 반환한다")
+        void existsByUserAndVideo_OtherUser_ReturnsFalse() {
+            // given
+            User otherUser = createAndSaveUser("other", "다른유저");
+            scrapRepository.save(createScrap(otherUser, testVideo));
+
+            // when
+            boolean exists = scrapRepository.existsByUserIdAndApiVideoId(
+                    testUser.getId(),
+                    testVideo.getApiVideoId()
+            );
+
+            // then
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUserIdAndApiVideoId 메서드는")
+    class FindByUserIdAndApiVideoIdTest {
+
+        @Test
+        @DisplayName("사용자의 스크랩을 조회한다")
+        void findByUserAndVideo_Exists_ReturnsScrap() {
+            // given
+            Scrap scrap = createScrap(testUser, testVideo);
+            scrapRepository.save(scrap);
+
+            // when
+            Optional<Scrap> found = scrapRepository.findByUserIdAndApiVideoId(
+                    testUser.getId(),
+                    testVideo.getApiVideoId()
+            );
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getUser()).isEqualTo(testUser);
+            assertThat(found.get().getVideo()).isEqualTo(testVideo);
+            assertThat(found.get().getApiVideoId()).isEqualTo(testVideo.getApiVideoId());
+        }
+
+        @Test
+        @DisplayName("스크랩이 없으면 빈 Optional을 반환한다")
+        void findByUserAndVideo_NotExists_ReturnsEmpty() {
+            // when
+            Optional<Scrap> found = scrapRepository.findByUserIdAndApiVideoId(
+                    testUser.getId(),
+                    "not-scraped"
+            );
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 스크랩은 조회되지 않는다")
+        void findByUserAndVideo_OtherUser_ReturnsEmpty() {
+            // given
+            User otherUser = createAndSaveUser("other", "다른유저");
+            scrapRepository.save(createScrap(otherUser, testVideo));
+
+            // when
+            Optional<Scrap> found = scrapRepository.findByUserIdAndApiVideoId(
+                    testUser.getId(),
+                    testVideo.getApiVideoId()
+            );
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUserIdOrderByCreatedAtDesc 메서드는")
+    class FindByUserIdOrderByCreatedAtDescTest {
+
+        @Test
+        @DisplayName("사용자의 스크랩 목록을 최신순으로 조회한다")
+        void findByUser_OrderByCreatedAt_ReturnsDescending() throws InterruptedException {
+            // given
+            Video video1 = createAndSaveVideo("video-1", "영상1");
+            Video video2 = createAndSaveVideo("video-2", "영상2");
+            Video video3 = createAndSaveVideo("video-3", "영상3");
+
+            scrapRepository.save(createScrap(testUser, video1));
+            Thread.sleep(10);
+            scrapRepository.save(createScrap(testUser, video2));
+            Thread.sleep(10);
+            scrapRepository.save(createScrap(testUser, video3));
+
+            // when
+            List<Scrap> found = scrapRepository.findByUserIdOrderByCreatedAtDesc(testUser.getId());
+
+            // then
+            assertThat(found).hasSize(3);
+            assertThat(found.get(0).getVideo()).isEqualTo(video3); // 가장 최근
+            assertThat(found.get(2).getVideo()).isEqualTo(video1); // 가장 오래됨
+        }
+
+        @Test
+        @DisplayName("스크랩이 없으면 빈 리스트를 반환한다")
+        void findByUser_NoScraps_ReturnsEmpty() {
+            // when
+            List<Scrap> found = scrapRepository.findByUserIdOrderByCreatedAtDesc(testUser.getId());
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 스크랩은 조회되지 않는다")
+        void findByUser_OtherUserScraps_NotIncluded() {
+            // given
+            User otherUser = createAndSaveUser("other-sub", "다른유저");
+            scrapRepository.save(createScrap(otherUser, testVideo));
+
+            // when
+            List<Scrap> found = scrapRepository.findByUserIdOrderByCreatedAtDesc(testUser.getId());
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("여러 영상을 스크랩해도 모두 조회된다")
+        void findByUser_MultipleVideos_ReturnsAll() {
+            // given
+            Video video1 = createAndSaveVideo("video-1", "영상1");
+            Video video2 = createAndSaveVideo("video-2", "영상2");
+            Video video3 = createAndSaveVideo("video-3", "영상3");
+
+            scrapRepository.save(createScrap(testUser, video1));
+            scrapRepository.save(createScrap(testUser, video2));
+            scrapRepository.save(createScrap(testUser, video3));
+
+            // when
+            List<Scrap> found = scrapRepository.findByUserIdOrderByCreatedAtDesc(testUser.getId());
+
+            // then
+            assertThat(found).hasSize(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("countScrapsByVideo 메서드는")
+    class CountScrapsByVideoTest {
+
+        @Test
+        @DisplayName("영상별 스크랩 횟수를 집계한다")
+        void countScrapsByVideo_MultipleVideos_ReturnsCount() {
+            // given
+            Video video1 = createAndSaveVideo("video-1", "영상1");
+            Video video2 = createAndSaveVideo("video-2", "영상2");
+
+            User user1 = createAndSaveUser("user1", "유저1");
+            User user2 = createAndSaveUser("user2", "유저2");
+            User user3 = createAndSaveUser("user3", "유저3");
+
+            // video1: 2회 스크랩
+            scrapRepository.save(createScrap(user1, video1));
+            scrapRepository.save(createScrap(user2, video1));
+
+            // video2: 1회 스크랩
+            scrapRepository.save(createScrap(user3, video2));
+
+            // when
+            List<Object[]> results = scrapRepository.countScrapsByVideo();
+
+            // then
+            assertThat(results).hasSize(2);
+            // 결과는 (apiVideoId, count) 형태
+
+            // video1 검증
+            Object[] video1Result = results.stream()
+                    .filter(r -> r[0].equals("video-1"))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(((Number) video1Result[1]).longValue()).isEqualTo(2L);
+
+            // video2 검증
+            Object[] video2Result = results.stream()
+                    .filter(r -> r[0].equals("video-2"))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(((Number) video2Result[1]).longValue()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("스크랩이 없으면 빈 리스트를 반환한다")
+        void countScrapsByVideo_NoScraps_ReturnsEmpty() {
+            // when
+            List<Object[]> results = scrapRepository.countScrapsByVideo();
+
+            // then
+            assertThat(results).isEmpty();
+        }
+
+        @Test
+        @DisplayName("같은 사용자가 여러 영상을 스크랩해도 정확히 집계한다")
+        void countScrapsByVideo_SameUserMultipleVideos_CountsSeparately() {
+            // given
+            Video video1 = createAndSaveVideo("video-1", "영상1");
+            Video video2 = createAndSaveVideo("video-2", "영상2");
+
+            scrapRepository.save(createScrap(testUser, video1));
+            scrapRepository.save(createScrap(testUser, video2));
+
+            // when
+            List<Object[]> results = scrapRepository.countScrapsByVideo();
+
+            // then
+            assertThat(results).hasSize(2);
+            // 각 영상마다 1회씩
+            assertThat(results).allMatch(r -> ((Number) r[1]).longValue() == 1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUserIdAndVideoId 메서드는")
+    class FindByUserIdAndVideoIdTest {
+
+        @Test
+        @DisplayName("사용자 ID와 비디오 ID로 스크랩을 조회한다")
+        void findByUserIdAndVideoId_Exists_ReturnsScrap() {
+            // given
+            Scrap scrap = createScrap(testUser, testVideo);
+            scrapRepository.save(scrap);
+
+            // when
+            Optional<Scrap> found = scrapRepository.findByUserIdAndVideoId(
+                    testUser.getId(),
+                    testVideo.getId()
+            );
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getUser()).isEqualTo(testUser);
+            assertThat(found.get().getVideo()).isEqualTo(testVideo);
+        }
+
+        @Test
+        @DisplayName("존재하지 않으면 빈 Optional을 반환한다")
+        void findByUserIdAndVideoId_NotExists_ReturnsEmpty() {
+            // when
+            Optional<Scrap> found = scrapRepository.findByUserIdAndVideoId(
+                    testUser.getId(),
+                    999L
+            );
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 스크랩은 조회되지 않는다")
+        void findByUserIdAndVideoId_OtherUser_ReturnsEmpty() {
+            // given
+            User otherUser = createAndSaveUser("other", "다른유저");
+            scrapRepository.save(createScrap(otherUser, testVideo));
+
+            // when
+            Optional<Scrap> found = scrapRepository.findByUserIdAndVideoId(
+                    testUser.getId(),
+                    testVideo.getId()
+            );
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    private User createAndSaveUser(String sub, String name) {
+        User user = User.builder()
+                .sub(sub)
+                .email(sub + "@example.com")
+                .name(name)
+                .role("ROLE_USER")
+                .picture("https://example.com/picture.jpg")
+                .build();
+        return userRepository.save(user);
+    }
+
+    private Video createAndSaveVideo(String apiVideoId, String title) {
+        Video video = Video.builder()
+                .apiVideoId(apiVideoId)
+                .title(title)
+                .description("테스트 설명")
+                .videoType(VideoType.VIDEO)
+                .viewCount("1000")
+                .likeCount("100")
+                .commentCount("50")
+                .thumbnailUrl("https://example.com/thumb.jpg")
+                .channelId("channel-123")
+                .channelName("테스트 채널")
+                .channelThumbnailUrl("https://example.com/channel.jpg")
+                .subscriberCount("10000")
+                .uploadedAt("2024-01-01T00:00:00Z")
+                .commentHistogram("{}")
+                .popularTimestamps("{}")
+                .aiAnalysisStatus(AIAnalysisStatus.PENDING)
+                .lastMetadataUpdatedAt(LocalDateTime.now())
+                .build();
+        return videoRepository.save(video);
+    }
+
+    private Scrap createScrap(User user, Video video) {
+        return Scrap.builder()
+                .user(user)
+                .video(video)
+                .apiVideoId(video.getApiVideoId())
+                .build();
+    }
+}

--- a/src/test/java/com/knu/sosuso/capstone/domain/video/repository/VideoRepositoryTest.java
+++ b/src/test/java/com/knu/sosuso/capstone/domain/video/repository/VideoRepositoryTest.java
@@ -1,0 +1,376 @@
+package com.knu.sosuso.capstone.domain.video.repository;
+
+import com.knu.sosuso.capstone.domain.video.entity.AIAnalysisStatus;
+import com.knu.sosuso.capstone.domain.video.entity.Video;
+import com.knu.sosuso.capstone.domain.video.entity.VideoType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("VideoRepository 통합 테스트")
+class VideoRepositoryTest {
+
+    @Autowired
+    private VideoRepository videoRepository;
+
+    @BeforeEach
+    void setUp() {
+        videoRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("findByApiVideoId 메서드는")
+    class FindByApiVideoIdTest {
+
+        @Test
+        @DisplayName("존재하는 영상을 조회한다")
+        void findByApiVideoId_Exists_ReturnsVideo() {
+            // given
+            Video video = createTestVideo("test-123", "테스트 영상");
+            videoRepository.save(video);
+
+            // when
+            Optional<Video> found = videoRepository.findByApiVideoId("test-123");
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getApiVideoId()).isEqualTo("test-123");
+            assertThat(found.get().getTitle()).isEqualTo("테스트 영상");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 영상은 빈 Optional을 반환한다")
+        void findByApiVideoId_NotExists_ReturnsEmpty() {
+            // when
+            Optional<Video> found = videoRepository.findByApiVideoId("not-exists");
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("UNIQUE 제약조건으로 중복 저장을 방지한다")
+        void findByApiVideoId_DuplicateApiVideoId_ThrowsException() {
+            // given
+            Video video1 = createTestVideo("duplicate-id", "영상1");
+            videoRepository.save(video1);
+
+            Video video2 = createTestVideo("duplicate-id", "영상2");
+
+            // when & then
+            org.junit.jupiter.api.Assertions.assertThrows(
+                    org.springframework.dao.DataIntegrityViolationException.class,
+                    () -> {
+                        videoRepository.save(video2);
+                        videoRepository.flush();
+                    }
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("findTop10ByAiAnalysisStatusOrderByUpdatedAtDesc 메서드는")
+    class FindTop10ByAiAnalysisStatusTest {
+
+        @Test
+        @DisplayName("특정 상태의 영상을 최신순으로 10개 조회한다")
+        void findTop10_PendingStatus_ReturnsLatest10() throws InterruptedException {
+            // given
+            for (int i = 0; i < 15; i++) {
+                Video video = createTestVideo("video-" + i, "영상" + i);
+                video.setAiAnalysisStatus(AIAnalysisStatus.PENDING);
+                videoRepository.save(video);
+                Thread.sleep(10); // updatedAt 차이를 위해
+            }
+
+            // when
+            List<Video> found = videoRepository
+                    .findTop10ByAiAnalysisStatusOrderByUpdatedAtDesc(AIAnalysisStatus.PENDING);
+
+            // then
+            assertThat(found).hasSize(10);
+            assertThat(found).allMatch(v -> v.getAiAnalysisStatus() == AIAnalysisStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태만 조회한다")
+        void findTop10_CompletedStatus_ReturnsOnlyCompleted() {
+            // given
+            Video pending = createTestVideo("pending-1", "대기중");
+            pending.setAiAnalysisStatus(AIAnalysisStatus.PENDING);
+
+            Video completed1 = createTestVideo("completed-1", "완료1");
+            completed1.setAiAnalysisStatus(AIAnalysisStatus.COMPLETED);
+
+            Video completed2 = createTestVideo("completed-2", "완료2");
+            completed2.setAiAnalysisStatus(AIAnalysisStatus.COMPLETED);
+
+            videoRepository.saveAll(List.of(pending, completed1, completed2));
+
+            // when
+            List<Video> found = videoRepository
+                    .findTop10ByAiAnalysisStatusOrderByUpdatedAtDesc(AIAnalysisStatus.COMPLETED);
+
+            // then
+            assertThat(found).hasSize(2);
+            assertThat(found).allMatch(v -> v.getAiAnalysisStatus() == AIAnalysisStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("결과가 10개 미만이면 있는 만큼만 반환한다")
+        void findTop10_LessThan10_ReturnsAll() {
+            // given
+            for (int i = 0; i < 5; i++) {
+                Video video = createTestVideo("video-" + i, "영상" + i);
+                video.setAiAnalysisStatus(AIAnalysisStatus.PENDING);
+                videoRepository.save(video);
+            }
+
+            // when
+            List<Video> found = videoRepository
+                    .findTop10ByAiAnalysisStatusOrderByUpdatedAtDesc(AIAnalysisStatus.PENDING);
+
+            // then
+            assertThat(found).hasSize(5);
+        }
+
+        @Test
+        @DisplayName("최신 영상이 먼저 조회된다")
+        void findTop10_OrderByUpdatedAt_ReturnsLatestFirst() throws InterruptedException {
+            // given
+            Video old = createTestVideo("old", "오래된 영상");
+            old.setAiAnalysisStatus(AIAnalysisStatus.PENDING);
+            videoRepository.save(old);
+
+            Thread.sleep(100);
+
+            Video recent = createTestVideo("recent", "최근 영상");
+            recent.setAiAnalysisStatus(AIAnalysisStatus.PENDING);
+            videoRepository.save(recent);
+
+            // when
+            List<Video> found = videoRepository
+                    .findTop10ByAiAnalysisStatusOrderByUpdatedAtDesc(AIAnalysisStatus.PENDING);
+
+            // then
+            assertThat(found).hasSize(2);
+            assertThat(found.get(0).getApiVideoId()).isEqualTo("recent");
+            assertThat(found.get(1).getApiVideoId()).isEqualTo("old");
+        }
+    }
+
+    @Nested
+    @DisplayName("findByDeletedTrueAndDeleteCheckedAtBefore 메서드는")
+    class FindByDeletedTrueTest {
+
+        @Test
+        @DisplayName("삭제되고 오래된 영상을 조회한다")
+        void findByDeletedTrue_OldVideos_ReturnsDeleted() {
+            // given
+            LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+
+            Video oldDeleted = createTestVideo("old-deleted", "오래된 삭제 영상");
+            oldDeleted.setDeleted(true);
+            oldDeleted.setDeleteCheckedAt(threshold.minusDays(1));
+
+            Video recentDeleted = createTestVideo("recent-deleted", "최근 삭제 영상");
+            recentDeleted.setDeleted(true);
+            recentDeleted.setDeleteCheckedAt(LocalDateTime.now());
+
+            Video notDeleted = createTestVideo("not-deleted", "삭제되지 않은 영상");
+            notDeleted.setDeleted(false);
+
+            videoRepository.saveAll(List.of(oldDeleted, recentDeleted, notDeleted));
+
+            // when
+            List<Video> found = videoRepository
+                    .findByDeletedTrueAndDeleteCheckedAtBefore(threshold);
+
+            // then
+            assertThat(found).hasSize(1);
+            assertThat(found.get(0).getApiVideoId()).isEqualTo("old-deleted");
+            assertThat(found.get(0).isDeleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("삭제되지 않은 영상은 조회되지 않는다")
+        void findByDeletedTrue_NotDeleted_ReturnsEmpty() {
+            // given
+            LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+
+            Video notDeleted = createTestVideo("not-deleted", "삭제 안됨");
+            notDeleted.setDeleted(false);
+            notDeleted.setDeleteCheckedAt(threshold.minusDays(1));
+            videoRepository.save(notDeleted);
+
+            // when
+            List<Video> found = videoRepository
+                    .findByDeletedTrueAndDeleteCheckedAtBefore(threshold);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("threshold 이후에 삭제 확인된 영상은 조회되지 않는다")
+        void findByDeletedTrue_AfterThreshold_NotIncluded() {
+            // given
+            LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+
+            Video afterThreshold = createTestVideo("after", "threshold 이후");
+            afterThreshold.setDeleted(true);
+            afterThreshold.setDeleteCheckedAt(threshold.plusDays(1));
+            videoRepository.save(afterThreshold);
+
+            // when
+            List<Video> found = videoRepository
+                    .findByDeletedTrueAndDeleteCheckedAtBefore(threshold);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findVideosNeedingMetadataUpdate 메서드는")
+    class FindVideosNeedingMetadataUpdateTest {
+
+        @Test
+        @DisplayName("쿼리 문법이 올바르게 작동한다")
+        void findVideosNeedingMetadataUpdate_QuerySyntax_Valid() {
+            // given
+            LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+
+            Video oldMetadata = createTestVideo("old-meta", "오래된 메타데이터");
+            oldMetadata.setLastMetadataUpdatedAt(threshold.minusDays(1));
+            oldMetadata.setDeleted(false);
+            videoRepository.save(oldMetadata);
+
+            // when - Scrap과 INNER JOIN이므로 Scrap이 없으면 결과 없음
+            List<Video> found = videoRepository
+                    .findVideosNeedingMetadataUpdate(threshold);
+
+            // then
+            // Scrap 없으면 빈 결과 (정상)
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("lastMetadataUpdatedAt이 null인 경우도 처리한다")
+        void findVideosNeedingMetadataUpdate_NullLastUpdated_QueryValid() {
+            // given
+            LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+
+            Video nullMetadata = createTestVideo("null-meta", "메타데이터 없음");
+            nullMetadata.setLastMetadataUpdatedAt(null);
+            nullMetadata.setDeleted(false);
+            videoRepository.save(nullMetadata);
+
+            // when
+            List<Video> found = videoRepository
+                    .findVideosNeedingMetadataUpdate(threshold);
+
+            // then
+            assertThat(found).isEmpty(); // Scrap 없으면 조회 안됨
+        }
+
+        @Test
+        @DisplayName("deleted가 true인 영상은 제외된다")
+        void findVideosNeedingMetadataUpdate_DeletedVideos_Excluded() {
+            // given
+            LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+
+            Video deletedVideo = createTestVideo("deleted", "삭제된 영상");
+            deletedVideo.setLastMetadataUpdatedAt(threshold.minusDays(1));
+            deletedVideo.setDeleted(true);
+            videoRepository.save(deletedVideo);
+
+            // when
+            List<Video> found = videoRepository
+                    .findVideosNeedingMetadataUpdate(threshold);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("save 메서드는")
+    class SaveTest {
+
+        @Test
+        @DisplayName("새로운 영상을 저장한다")
+        void save_NewVideo_SavesSuccessfully() {
+            // given
+            Video video = createTestVideo("new-video", "새 영상");
+
+            // when
+            Video saved = videoRepository.save(video);
+
+            // then
+            assertThat(saved.getId()).isNotNull();
+            assertThat(saved.getApiVideoId()).isEqualTo("new-video");
+        }
+
+        @Test
+        @DisplayName("영상 정보를 업데이트한다")
+        void save_ExistingVideo_UpdatesSuccessfully() {
+            // given
+            Video video = createTestVideo("test", "원래 제목");
+            Video saved = videoRepository.save(video);
+
+            // when
+            saved.setTitle("변경된 제목");
+            saved.setViewCount("9999");
+            videoRepository.save(saved);
+
+            // then
+            Video updated = videoRepository.findByApiVideoId("test").orElseThrow();
+            assertThat(updated.getTitle()).isEqualTo("변경된 제목");
+            assertThat(updated.getViewCount()).isEqualTo("9999");
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    private Video createTestVideo(String apiVideoId, String title) {
+        return createTestVideo(apiVideoId, title, VideoType.VIDEO);
+    }
+
+    private Video createTestVideo(String apiVideoId, String title, VideoType videoType) {
+        return Video.builder()
+                .apiVideoId(apiVideoId)
+                .title(title)
+                .description("테스트 설명")
+                .videoType(videoType)
+                .viewCount("1000")
+                .likeCount("100")
+                .commentCount("50")
+                .thumbnailUrl("https://example.com/thumb.jpg")
+                .channelId("channel-123")
+                .channelName("테스트 채널")
+                .channelThumbnailUrl("https://example.com/channel.jpg")
+                .subscriberCount("10000")
+                .uploadedAt("2024-01-01T00:00:00Z")
+                .commentHistogram("{}")
+                .popularTimestamps("{}")
+                .aiAnalysisStatus(AIAnalysisStatus.PENDING)
+                .lastMetadataUpdatedAt(LocalDateTime.now())
+                .commentsDisabled(false)
+                .hasNoComments(false)
+                .deleted(false)
+                .build();
+    }
+}

--- a/src/test/java/com/knu/sosuso/capstone/domain/video/repository/VideoStatsRepositoryTest.java
+++ b/src/test/java/com/knu/sosuso/capstone/domain/video/repository/VideoStatsRepositoryTest.java
@@ -1,0 +1,171 @@
+package com.knu.sosuso.capstone.domain.video.repository;
+
+import com.knu.sosuso.capstone.domain.video.entity.VideoStats;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("VideoStatsRepository 통합 테스트")
+class VideoStatsRepositoryTest {
+
+    @Autowired
+    private VideoStatsRepository videoStatsRepository;
+
+    @BeforeEach
+    void setUp() {
+        videoStatsRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("findTopByPopularityScore 메서드는")
+    class FindTopByPopularityScoreTest {
+
+        @Test
+        @DisplayName("인기 점수 순으로 영상을 조회한다")
+        void findTopByPopularityScore_OrderByScore_ReturnsDescending() {
+            // given
+            VideoStats stats1 = createVideoStats("video-1", 100.0);
+            VideoStats stats2 = createVideoStats("video-2", 500.0);
+            VideoStats stats3 = createVideoStats("video-3", 300.0);
+            videoStatsRepository.save(stats1);
+            videoStatsRepository.save(stats2);
+            videoStatsRepository.save(stats3);
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<VideoStats> found = videoStatsRepository.findTopByPopularityScore(pageable);
+
+            // then
+            assertThat(found.getContent()).hasSize(3);
+            assertThat(found.getContent().get(0).getPopularityScore()).isEqualTo(500.0);
+            assertThat(found.getContent().get(1).getPopularityScore()).isEqualTo(300.0);
+            assertThat(found.getContent().get(2).getPopularityScore()).isEqualTo(100.0);
+        }
+
+        @Test
+        @DisplayName("점수가 0보다 큰 영상만 조회한다")
+        void findTopByPopularityScore_OnlyPositiveScore_ReturnsFiltered() {
+            // given
+            VideoStats positive1 = createVideoStats("video-1", 100.0);
+            VideoStats positive2 = createVideoStats("video-2", 200.0);
+            VideoStats zero = createVideoStats("video-3", 0.0);
+            VideoStats negative = createVideoStats("video-4", -10.0);
+
+            videoStatsRepository.save(positive1);
+            videoStatsRepository.save(positive2);
+            videoStatsRepository.save(zero);
+            videoStatsRepository.save(negative);
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<VideoStats> found = videoStatsRepository.findTopByPopularityScore(pageable);
+
+            // then
+            assertThat(found.getContent()).hasSize(2);
+            assertThat(found.getContent()).allMatch(s -> s.getPopularityScore() > 0);
+        }
+
+        @Test
+        @DisplayName("페이징을 지원한다")
+        void findTopByPopularityScore_WithPagination_ReturnsPagedResults() {
+            // given
+            for (int i = 1; i <= 15; i++) {
+                VideoStats stats = createVideoStats("video-" + i, (double) i * 10);
+                videoStatsRepository.save(stats);
+            }
+
+            Pageable page1 = PageRequest.of(0, 5);
+            Pageable page2 = PageRequest.of(1, 5);
+
+            // when
+            Page<VideoStats> firstPage = videoStatsRepository.findTopByPopularityScore(page1);
+            Page<VideoStats> secondPage = videoStatsRepository.findTopByPopularityScore(page2);
+
+            // then
+            assertThat(firstPage.getContent()).hasSize(5);
+            assertThat(secondPage.getContent()).hasSize(5);
+            assertThat(firstPage.getTotalElements()).isEqualTo(15);
+            assertThat(firstPage.getTotalPages()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("결과가 없으면 빈 페이지를 반환한다")
+        void findTopByPopularityScore_NoStats_ReturnsEmpty() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<VideoStats> found = videoStatsRepository.findTopByPopularityScore(pageable);
+
+            // then
+            assertThat(found.getContent()).isEmpty();
+            assertThat(found.getTotalElements()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("save 메서드는")
+    class SaveTest {
+
+        @Test
+        @DisplayName("새로운 통계를 저장한다")
+        void save_NewStats_SavesSuccessfully() {
+            // given
+            VideoStats stats = createVideoStats("new-video", 123.45);
+
+            // when
+            VideoStats saved = videoStatsRepository.save(stats);
+
+            // then
+            assertThat(saved.getApiVideoId()).isEqualTo("new-video");
+            assertThat(saved.getPopularityScore()).isEqualTo(123.45);
+        }
+
+        @Test
+        @DisplayName("기존 통계를 업데이트한다")
+        void save_ExistingStats_UpdatesSuccessfully() {
+            // given
+            VideoStats stats = createVideoStats("video-123", 100.0);
+            videoStatsRepository.save(stats);
+
+            // when
+            stats.setPopularityScore(999.0);
+            stats.setViewCountRecent(500);
+            stats.setScrapCount(50);
+            VideoStats updated = videoStatsRepository.save(stats);
+
+            // then
+            VideoStats found = videoStatsRepository.findById("video-123").orElseThrow();
+            assertThat(found.getPopularityScore()).isEqualTo(999.0);
+            assertThat(found.getViewCountRecent()).isEqualTo(500);
+            assertThat(found.getScrapCount()).isEqualTo(50);
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    private VideoStats createVideoStats(String apiVideoId, Double popularityScore) {
+        VideoStats stats = new VideoStats();
+        stats.setApiVideoId(apiVideoId);
+        stats.setPopularityScore(popularityScore);
+        stats.setViewCountRecent(10);
+        stats.setScrapCount(5);
+        stats.setLastCalculatedAt(LocalDateTime.now());
+        return stats;
+    }
+}

--- a/src/test/java/com/knu/sosuso/capstone/domain/video/repository/VideoViewLogRepositoryTest.java
+++ b/src/test/java/com/knu/sosuso/capstone/domain/video/repository/VideoViewLogRepositoryTest.java
@@ -1,0 +1,246 @@
+package com.knu.sosuso.capstone.domain.video.repository;
+
+import com.knu.sosuso.capstone.domain.video.entity.VideoViewLog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("VideoViewLogRepository 통합 테스트")
+class VideoViewLogRepositoryTest {
+
+    @Autowired
+    private VideoViewLogRepository videoViewLogRepository;
+
+    @BeforeEach
+    void setUp() {
+        videoViewLogRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("countViewsByVideoSince 메서드는")
+    class CountViewsByVideoSinceTest {
+
+        @Test
+        @DisplayName("특정 기간 이후의 조회수를 집계한다")
+        void countViewsSince_WithinPeriod_ReturnsCount() {
+            // given
+            LocalDateTime since = LocalDateTime.now().minusDays(7);
+
+            // video-1: 3회 조회
+            saveViewLog("video-1", 1L, since.plusDays(1));
+            saveViewLog("video-1", 2L, since.plusDays(2));
+            saveViewLog("video-1", 3L, since.plusDays(3));
+
+            // video-2: 2회 조회
+            saveViewLog("video-2", 1L, since.plusDays(1));
+            saveViewLog("video-2", 2L, since.plusDays(2));
+
+            // when
+            List<Object[]> results = videoViewLogRepository.countViewsByVideoSince(since);
+
+            // then
+            assertThat(results).hasSize(2);
+            // 결과는 [apiVideoId, count] 형태
+        }
+
+        @Test
+        @DisplayName("기간 이전의 로그는 집계하지 않는다")
+        void countViewsSince_BeforePeriod_NotIncluded() {
+            // given
+            LocalDateTime since = LocalDateTime.now().minusDays(7);
+
+            // 기간 이후
+            saveViewLog("video-1", 1L, since.plusDays(1));
+
+            // 기간 이전
+            saveViewLog("video-1", 2L, since.minusDays(1));
+
+            // when
+            List<Object[]> results = videoViewLogRepository.countViewsByVideoSince(since);
+
+            // then
+            assertThat(results).hasSize(1);
+            // video-1의 count는 1이어야 함
+        }
+
+        @Test
+        @DisplayName("로그가 없으면 빈 리스트를 반환한다")
+        void countViewsSince_NoLogs_ReturnsEmpty() {
+            // given
+            LocalDateTime since = LocalDateTime.now().minusDays(7);
+
+            // when
+            List<Object[]> results = videoViewLogRepository.countViewsByVideoSince(since);
+
+            // then
+            assertThat(results).isEmpty();
+        }
+
+        @Test
+        @DisplayName("동일 영상의 여러 조회를 정확히 집계한다")
+        void countViewsSince_MultipleViews_CountsAll() {
+            // given
+            LocalDateTime since = LocalDateTime.now().minusDays(7);
+            String videoId = "popular-video";
+
+            // 10회 조회
+            for (int i = 1; i <= 10; i++) {
+                saveViewLog(videoId, (long) i, since.plusHours(i));
+            }
+
+            // when
+            List<Object[]> results = videoViewLogRepository.countViewsByVideoSince(since);
+
+            // then
+            assertThat(results).hasSize(1);
+            Object[] result = results.get(0);
+            assertThat(result[0]).isEqualTo(videoId);
+            assertThat(((Number) result[1]).longValue()).isEqualTo(10L);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteOldLogs 메서드는")
+    class DeleteOldLogsTest {
+
+        @Test
+        @DisplayName("기준일 이전의 오래된 로그를 삭제한다")
+        void deleteOldLogs_BeforeDate_DeletesOldLogs() {
+            // given
+            LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+
+            // 오래된 로그
+            saveViewLog("video-1", 1L, threshold.minusDays(1));
+            saveViewLog("video-1", 2L, threshold.minusDays(2));
+
+            // 최근 로그
+            saveViewLog("video-2", 3L, threshold.plusDays(1));
+
+            // when
+            videoViewLogRepository.deleteOldLogs(threshold);
+            videoViewLogRepository.flush();
+
+            // then
+            List<VideoViewLog> remaining = videoViewLogRepository.findAll();
+            assertThat(remaining).hasSize(1);
+            assertThat(remaining.get(0).getApiVideoId()).isEqualTo("video-2");
+        }
+
+        @Test
+        @DisplayName("기준일 정확히 일치하는 로그는 삭제하지 않는다")
+        void deleteOldLogs_ExactDate_NotDeleted() {
+            // given
+            LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+
+            // 정확히 threshold 시간
+            saveViewLog("video-1", 1L, threshold);
+
+            // when
+            videoViewLogRepository.deleteOldLogs(threshold);
+            videoViewLogRepository.flush();
+
+            // then
+            List<VideoViewLog> remaining = videoViewLogRepository.findAll();
+            assertThat(remaining).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("삭제할 로그가 없으면 아무 것도 삭제하지 않는다")
+        void deleteOldLogs_NoOldLogs_NoChange() {
+            // given
+            LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+            saveViewLog("video-1", 1L, threshold.plusDays(1));
+
+            // when
+            videoViewLogRepository.deleteOldLogs(threshold);
+            videoViewLogRepository.flush();
+
+            // then
+            List<VideoViewLog> remaining = videoViewLogRepository.findAll();
+            assertThat(remaining).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("모든 로그가 오래되었으면 전부 삭제한다")
+        void deleteOldLogs_AllOld_DeletesAll() {
+            // given
+            LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+
+            saveViewLog("video-1", 1L, threshold.minusDays(10));
+            saveViewLog("video-2", 2L, threshold.minusDays(20));
+            saveViewLog("video-3", 3L, threshold.minusDays(30));
+
+            // when
+            videoViewLogRepository.deleteOldLogs(threshold);
+            videoViewLogRepository.flush();
+
+            // then
+            List<VideoViewLog> remaining = videoViewLogRepository.findAll();
+            assertThat(remaining).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("save 메서드는")
+    class SaveTest {
+
+        @Test
+        @DisplayName("새로운 조회 로그를 저장한다")
+        void save_NewLog_SavesSuccessfully() {
+            // given
+            VideoViewLog log = VideoViewLog.builder()
+                    .apiVideoId("test-video")
+                    .userId(1L)
+                    .viewedAt(LocalDateTime.now())
+                    .build();
+
+            // when
+            VideoViewLog saved = videoViewLogRepository.save(log);
+
+            // then
+            assertThat(saved.getId()).isNotNull();
+            assertThat(saved.getApiVideoId()).isEqualTo("test-video");
+            assertThat(saved.getUserId()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("userId가 null이어도 저장된다 (비로그인 사용자)")
+        void save_NullUserId_SavesSuccessfully() {
+            // given
+            VideoViewLog log = VideoViewLog.builder()
+                    .apiVideoId("test-video")
+                    .userId(null)
+                    .viewedAt(LocalDateTime.now())
+                    .build();
+
+            // when
+            VideoViewLog saved = videoViewLogRepository.save(log);
+
+            // then
+            assertThat(saved.getId()).isNotNull();
+            assertThat(saved.getUserId()).isNull();
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    private void saveViewLog(String apiVideoId, Long userId, LocalDateTime viewedAt) {
+        VideoViewLog log = VideoViewLog.builder()
+                .apiVideoId(apiVideoId)
+                .userId(userId)
+                .viewedAt(viewedAt)
+                .build();
+        videoViewLogRepository.save(log);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,60 @@
+# 테스트 환경 설정
+# src/test/resources/application.yml
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:A
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+
+  h2:
+    console:
+      enabled: true
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-name: google
+            client-id: dummy-test-client-id
+            client-secret: dummy-test-secret
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/test
+            scope:
+              - email
+              - profile
+
+  cache:
+    type: caffeine
+
+jwt:
+  secret: dummy-test-jwt-secret-key-for-unit-tests-only-minimum-256-bits-required
+
+youtube:
+  api:
+    key: dummy-test-youtube-api-key
+
+openai:
+  model: gpt-4
+  api:
+    key: dummy-test-openai-api-key
+    url: https://api.openai.com/v1/chat/completions
+
+fastapi:
+  url: http://localhost:8000/analyze
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    com.knu.sosuso.capstone: DEBUG

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     password:
 
   jpa:
-    hibernate:A
+    hibernate:
       ddl-auto: create-drop
     show-sql: true
     properties:


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #156 
---
### 📌 요약
- Repository Layer 테스트 코드 작성 및 사용하지 않는 코드 정리

### ✅ 작업 내용
- Repository Layer 통합 테스트 작성
  - VideoRepository 테스트 (20개)
  - CommentRepository 테스트 (25개)
  - ScrapRepository 테스트 (15개)
  - UserRepository 테스트 (4개)
  - FavoriteChannelRepository 테스트 (9개)
  - VideoStatsRepository 테스트 (6개)
  - VideoViewLogRepository 테스트 (3개)

- H2 Database 테스트 환경 설정
  - Spring Security Test 의존성 추가
  - application.yml에 H2 설정 추가

- User 엔티티 수정
  - 'user' 테이블명에 백틱 추가 (H2 예약어 충돌 해결)

- 코드 정리
  - 사용하지 않는 Repository 메서드 삭제
  - 미사용 import 제거
  - Dead code 제거

### 📚 참고 자료, 할 말
- 모든 테스트 통과 확인 완료