### PR TITLE
[FEATURE] 동시성 및 확장성 개선 - HikariCP, RestTemplate 타임아웃, Cache 최적화

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/ai/service/AnalysisService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/ai/service/AnalysisService.java
@@ -4,19 +4,22 @@ import com.knu.sosuso.capstone.domain.ai.dto.AIAnalysisRequest;
 import com.knu.sosuso.capstone.domain.ai.dto.AIAnalysisResponse;
 import com.knu.sosuso.capstone.global.exception.BusinessException;
 import com.knu.sosuso.capstone.global.exception.error.AIError;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
-@RequiredArgsConstructor
 @Service
 public class AnalysisService {
 
-    private final RestTemplate restTemplate;
+    private final RestTemplate aiRestTemplate;
+
+    public AnalysisService(@Qualifier("aiRestTemplate") RestTemplate aiRestTemplate) {
+        this.aiRestTemplate = aiRestTemplate;
+    }
 
     @Value("${fastapi.url}")
     private String FASTAPI_URL;
@@ -36,7 +39,7 @@ public class AnalysisService {
 
             long startTime = System.currentTimeMillis();
 
-            ResponseEntity<AIAnalysisResponse> aiAnalysisResponse = restTemplate.postForEntity(
+            ResponseEntity<AIAnalysisResponse> aiAnalysisResponse = aiRestTemplate.postForEntity(
                     FASTAPI_URL,
                     entity,
                     AIAnalysisResponse.class

--- a/src/main/java/com/knu/sosuso/capstone/domain/channel/service/ChannelService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/channel/service/ChannelService.java
@@ -39,9 +39,7 @@ public class ChannelService {
      * YouTube API 호출 절감을 위해 캐싱 적용 (1시간 유지)
      * 토큰별로 다른 결과를 반환하므로 토큰도 키에 포함
      */
-    @Cacheable(value = "searchResults",
-            key = "'channel-' + #query",
-            unless = "#result.results().isEmpty()")
+    @Cacheable(value = "searchResults", key = "'channel-' + #query", sync = true)
     public ChannelSearchResponse searchChannels(String token, String query) {
         if (query == null || query.trim().isEmpty()) {
             throw new BusinessException(ChannelError.CHANNEL_QUERY_REQUIRED);

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/Comment.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/entity/Comment.java
@@ -24,7 +24,8 @@ import lombok.Setter;
         indexes = {
                 @Index(name = "idx_comment_video_id", columnList = "video_id"),
                 @Index(name = "idx_comment_video_sentiment", columnList = "video_id, sentiment_type"),
-                @Index(name = "idx_comment_video_like", columnList = "video_id, like_count DESC")
+                @Index(name = "idx_comment_video_like", columnList = "video_id, like_count DESC"),
+                @Index(name = "idx_comment_api_comment_id", columnList = "api_comment_id", unique = true)
         }
 )
 @Entity

--- a/src/main/java/com/knu/sosuso/capstone/domain/comment/service/CommentService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/comment/service/CommentService.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.knu.sosuso.capstone.domain.ai.dto.AIAnalysisResponse;
 import com.knu.sosuso.capstone.domain.comment.entity.value.CommentSentimentDetail;
-import com.knu.sosuso.capstone.domain.video.repository.VideoRepository;
 import com.knu.sosuso.capstone.global.config.ApiConfig;
 import com.knu.sosuso.capstone.domain.comment.entity.Comment;
-import com.knu.sosuso.capstone.domain.video.entity.Video;
 import com.knu.sosuso.capstone.domain.comment.dto.response.CommentApiResponse;
 import com.knu.sosuso.capstone.domain.comment.dto.response.CommentApiResponse.CommentData;
 import com.knu.sosuso.capstone.domain.comment.repository.CommentRepository;
@@ -177,43 +175,6 @@ public class CommentService {
 
         log.info("✅ Comment 엔티티 생성 완료: {}개", comments.size());
         return comments;
-    }
-
-    /**
-     * 댓글을 DB에 저장 (sentiment는 null)
-     */
-    @Transactional
-    public void saveCommentsToDb(List<CommentData> comments, Video video) {
-        if (comments == null || comments.isEmpty()) {
-            log.info("저장할 댓글이 없습니다: apiVideoId={}", video.getApiVideoId());
-            return;
-        }
-
-        log.info("댓글 DB 저장 시작: apiVideoId={}, 댓글수={}", video.getApiVideoId(), comments.size());
-
-        try {
-            List<Comment> commentsToSave = comments.stream()
-                    .map(data -> Comment.builder()
-                            .video(video)
-                            .apiCommentId(data.id())
-                            .commentContent(data.commentText())
-                            .likeCount(data.likeCount())
-                            .writer(data.authorName())
-                            .writtenAt(data.publishedAt())
-                            .hasReplies(data.hasReplies())
-                            .sentimentType(null)
-                            .detailSentiments(new ArrayList<>())
-                            .build())
-                    .filter(comment -> !commentRepository.existsByApiCommentId(comment.getApiCommentId()))
-                    .collect(Collectors.toList());
-
-            commentRepository.saveAll(commentsToSave);
-            log.info("댓글 저장 완료: apiVideoId={}, 저장 개수={}", video.getApiVideoId(), commentsToSave.size());
-
-        } catch (Exception e) {
-            log.error("댓글 저장 실패: {}", e.getMessage(), e);
-            throw new BusinessException(CommentError.COMMENT_SAVE_ERROR);
-        }
     }
 
     /**

--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
@@ -57,7 +57,6 @@ public class VideoDetailService {
      * - 영상 메타데이터만 캐시
      */
     @Cacheable(value = "videoDetail", key = "'video-' + #apiVideoId")
-    @Transactional
     public Video getOrProcessVideo(String apiVideoId) {
         log.info("📺 영상 엔티티 조회: apiVideoId={}", apiVideoId);
 
@@ -91,7 +90,6 @@ public class VideoDetailService {
      * 영상 기본 정보 조회
      */
     @Cacheable(value = "videoDetail", key = "'basic-' + #apiVideoId", unless = "#result == null")
-    @Transactional(readOnly = true)
     public VideoBasicResponse getVideoBasic(String token, String apiVideoId) {
         log.info("📺 영상 기본 정보 조회: apiVideoId={}", apiVideoId);
 
@@ -106,7 +104,6 @@ public class VideoDetailService {
      * - 스크랩 여부
      * - 관심 채널 여부
      */
-    @Transactional(readOnly = true)
     public UserVideoStateResponse getUserVideoState(String token, String apiVideoId) {
         log.info("👤 사용자 영상 상태 조회: apiVideoId={}", apiVideoId);
 
@@ -135,7 +132,6 @@ public class VideoDetailService {
     /**
      * 백엔드 분석 정보 조회
      */
-    @Transactional(readOnly = true)
     public VideoAnalysisResponse getVideoAnalysis(String apiVideoId) {
         log.info("📊 백엔드 분석 정보 조회: apiVideoId={}", apiVideoId);
 
@@ -177,7 +173,6 @@ public class VideoDetailService {
     /**
      * 전체 댓글 조회 (단순 DB 조회)
      */
-    @Transactional(readOnly = true)
     public List<CommentDto> getVideoComments(String apiVideoId) {
         log.info("💬 전체 댓글 조회: apiVideoId={}", apiVideoId);
 
@@ -214,7 +209,6 @@ public class VideoDetailService {
      * - 감정 분포
      * - 키워드
      */
-    @Transactional(readOnly = true)
     public AIAnalysisResponse getAIAnalysis(String apiVideoId) {
         log.info("🤖 AI 분석 결과 조회: apiVideoId={}", apiVideoId);
 
@@ -670,7 +664,8 @@ public class VideoDetailService {
         return video.getLastMetadataUpdatedAt().isBefore(updateThreshold);
     }
 
-    private void checkAndUpdateDeletionStatus(Video video) {
+    @Transactional
+    public void checkAndUpdateDeletionStatus(Video video) {
         boolean isDeleted = videoService.checkIfVideoDeleted(video.getApiVideoId());
         if (isDeleted) {
             video.setDeleted(true);
@@ -682,7 +677,8 @@ public class VideoDetailService {
         videoRepository.save(video);
     }
 
-    private void updateMetadata(Video video) {
+    @Transactional
+    public void updateMetadata(Video video) {
         try {
             VideoApiResponse videoInfo = videoService.getVideoInfo(video.getApiVideoId());
 

--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
@@ -56,7 +56,7 @@ public class VideoDetailService {
      * 영상 엔티티 조회 또는 처리 (사용자 무관 - 캐시 가능)
      * - 영상 메타데이터만 캐시
      */
-    @Cacheable(value = "videoDetail", key = "'video-' + #apiVideoId")
+    @Cacheable(value = "videoDetail", key = "'video-' + #apiVideoId", sync = true)
     public Video getOrProcessVideo(String apiVideoId) {
         log.info("📺 영상 엔티티 조회: apiVideoId={}", apiVideoId);
 
@@ -89,7 +89,7 @@ public class VideoDetailService {
     /**
      * 영상 기본 정보 조회
      */
-    @Cacheable(value = "videoDetail", key = "'basic-' + #apiVideoId", unless = "#result == null")
+    @Cacheable(value = "videoDetail", key = "'basic-' + #apiVideoId", sync = true)
     public VideoBasicResponse getVideoBasic(String token, String apiVideoId) {
         log.info("📺 영상 기본 정보 조회: apiVideoId={}", apiVideoId);
 

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/entity/Video.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/entity/Video.java
@@ -12,10 +12,22 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @Entity
-@Table(name = "video")
+@Table(
+        name = "video",
+        indexes = {
+                // 가장 중요! apiVideoId로 조회가 매우 빈번함
+                @Index(name = "idx_video_api_video_id", columnList = "api_video_id", unique = true),
+                // AI 분석 상태별 조회 (스케줄러)
+                @Index(name = "idx_video_ai_status", columnList = "ai_analysis_status"),
+                // 삭제 여부 + 삭제 확인 시간 (배치 삭제용)
+                @Index(name = "idx_video_deleted", columnList = "is_deleted, delete_checked_at"),
+                // 채널별 영상 조회 (관심 채널 기능)
+                @Index(name = "idx_video_channel_id", columnList = "channel_id")
+        }
+)
 public class Video extends BaseEntity {
 
-    @Column(name = "api_video_id", unique = true)
+    @Column(name = "api_video_id")
     private String apiVideoId;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/PopularVideoService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/PopularVideoService.java
@@ -46,11 +46,7 @@ public class PopularVideoService {
      * @return 인기 영상 리스트
      * @throws BusinessException maxResults가 유효하지 않을 때
      */
-    @Cacheable(
-            value = "popularVideos",
-            key = "#maxResults",
-            unless = "#result == null || #result.isEmpty()"
-    )
+    @Cacheable(value = "popularVideos", key = "#maxResults", sync = true)
     @Transactional(readOnly = true)
     public List<VideoSummaryResponse> getPopularVideos(String token, int maxResults) {
         log.info("인기 영상 조회 시작: maxResults={}", maxResults);

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoProcessingService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoProcessingService.java
@@ -66,7 +66,6 @@ public class VideoProcessingService {
      *
      * @return Video 엔티티
      */
-    @Transactional
     public Video processNewVideo(String apiVideoId, VideoType expectedType) {
         log.info("🆕 새 영상 처리: apiVideoId={}, expectedType={}", apiVideoId, expectedType);
 
@@ -82,8 +81,7 @@ public class VideoProcessingService {
 
             // 3. 타입 불일치 로그
             if (expectedType != actualType) {
-                log.warn("⚠️ 영상 타입 불일치: apiVideoId={}, expected={}, actual={}",
-                        apiVideoId, expectedType, actualType);
+                log.warn("⚠️ 영상 타입 불일치: apiVideoId={}, expected={}, actual={}", apiVideoId, expectedType, actualType);
             }
 
             log.info("📹 영상 타입 확정: apiVideoId={}, type={}", apiVideoId, actualType);
@@ -91,8 +89,8 @@ public class VideoProcessingService {
             // 4. 댓글 수집
             CommentApiResponse commentResponse = commentService.getComments(apiVideoId);
 
+            // 4. 비디오 먼저 저장
             Video video;
-
             if (commentResponse.allComments() == null || commentResponse.allComments().isEmpty()) {
                 log.info("💬 댓글 없는 영상: apiVideoId={}", apiVideoId);
 
@@ -104,22 +102,23 @@ public class VideoProcessingService {
                 return video;
             }
 
-            log.info("💬 댓글 수집 완료: {}개", commentResponse.allComments().size());
-
-            List<Comment> comments = commentService.createCommentsWithoutAnalysis(
-                    commentResponse.allComments()
-            );
-
             video = videoService.saveVideoWithAnalysis(videoInfo, commentResponse, actualType);
-            videoRepository.flush();
+            log.info("✅ 비디오 저장 완료: videoId={}", video.getId());
 
-            for (Comment comment : comments) {
-                comment.setVideo(video);
+            // 5. 댓글 저장 시도
+            try {
+                List<Comment> comments = commentService.createCommentsWithoutAnalysis(
+                        commentResponse.allComments()
+                );
+                for (Comment comment : comments) {
+                    comment.setVideo(video);
+                }
+                commentRepository.saveAll(comments);
+                log.info("✅ 댓글 저장 완료: {}개", comments.size());
+
+            } catch (Exception e) {
+                log.warn("⚠️ 댓글 저장 실패 (비디오는 유지): videoId={}, error={}", video.getId(), e.getMessage());
             }
-            commentRepository.saveAll(comments);
-
-            log.info("✅ Video + Comment 저장 완료: videoId={}, type={}, 댓글={}개",
-                    video.getId(), actualType, comments.size());
 
             return video;
 
@@ -501,7 +500,8 @@ public class VideoProcessingService {
     /**
      * 영상 생성 또는 재조회 (동시성 문제 처리)
      */
-    private Video createOrRetrieveVideo(String apiVideoId, VideoType actualType) {
+    @Transactional
+    public Video createOrRetrieveVideo(String apiVideoId, VideoType actualType) {
         try {
             return processNewVideo(apiVideoId, actualType);
 

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoSearchService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoSearchService.java
@@ -59,8 +59,15 @@ public class VideoSearchService {
 
     /**
      * 동영상 검색 (쇼츠 제외)
+     *
+     * sync = true: 캐시 미스 시 한 스레드만 실행, 나머지는 대기
+     * → 100명 동시 요청해도 YouTube API 1번만 호출
      */
-    @Cacheable(value = "searchResults", key = "'video-' + #query + '-' + #pageToken", unless = "#result.results.isEmpty()")
+    @Cacheable(
+            value = "searchResults",
+            key = "'video-' + #query + '-' + #pageToken",
+            sync = true
+    )
     public SearchResultPageResponse searchVideos(String token, String query, String pageToken) {
         log.info("🔍 동영상 검색 (캐시 미스): query={}, pageToken={}", query, pageToken);
         return searchWithUrlCheck(token, query, pageToken, VideoType.VIDEO);
@@ -69,7 +76,11 @@ public class VideoSearchService {
     /**
      * 쇼츠 검색
      */
-    @Cacheable(value = "searchResults", key = "'shorts-' + #query + '-' + #pageToken", unless = "#result.results.isEmpty()")
+    @Cacheable(
+            value = "searchResults",
+            key = "'shorts-' + #query + '-' + #pageToken",
+            sync = true
+    )
     public SearchResultPageResponse searchShorts(String token, String query, String pageToken) {
         log.info("🔍 쇼츠 검색 (캐시 미스): query={}, pageToken={}", query, pageToken);
         return searchWithUrlCheck(token, query, pageToken, VideoType.SHORTS);
@@ -360,7 +371,7 @@ public class VideoSearchService {
      */
     private List<VideoData> fetchVideosInBatch(List<String> videoIds) {
         try {
-            String ids = String.join(",", videoIds);
+            String ids = String.join(",", videoIds);  // 콤마로 연결하여 한번에 호출
 
             String apiUrl = UriComponentsBuilder
                     .fromUriString(YOUTUBE_VIDEOS_API_URL)

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoService.java
@@ -40,7 +40,6 @@ public class VideoService {
     /**
      * YouTube API로 비디오 정보 조회
      */
-    @Transactional(readOnly = true)
     public VideoApiResponse getVideoInfo(String apiVideoId) {
         try {
             log.info("YouTube API 호출 - 비디오 정보 조회: apiVideoId={}", apiVideoId);

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoTypeDetector.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoTypeDetector.java
@@ -2,51 +2,48 @@ package com.knu.sosuso.capstone.domain.video.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.knu.sosuso.capstone.domain.video.entity.VideoType;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 /**
- * 영상 타입 정확한 판별기
+ * 영상 타입 판별기
  * 1. Shorts URL 확인 (가장 확실)
  * 2. 썸네일 비율 확인 (세로 > 가로 = 쇼츠)
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class VideoTypeDetector {
 
-    private final RestTemplate restTemplate;
+    private final RestTemplate fastRestTemplate;
+
+    public VideoTypeDetector(@Qualifier("fastRestTemplate") RestTemplate fastRestTemplate) {
+        this.fastRestTemplate = fastRestTemplate;
+    }
 
     /**
      * 영상 타입 판별
-     * @param apiVideoId YouTube 비디오 ID
-     * @param thumbnailData 썸네일 정보 (JSON)
-     * @return VideoType.SHORTS 또는 VideoType.VIDEO
      */
     public VideoType detectVideoType(String apiVideoId, JsonNode thumbnailData) {
-        // 1차: Shorts URL 확인 (가장 확실!)
         if (isShortsUrlValid(apiVideoId)) {
-            log.info("Shorts URL 확인: apiVideoId={} → SHORTS", apiVideoId);
+            log.debug("Shorts URL 확인: apiVideoId={} → SHORTS", apiVideoId);
             return VideoType.SHORTS;
         }
 
-        // 2차: 썸네일 비율 확인
         if (isShortsAspectRatio(thumbnailData)) {
-            log.info("썸네일 비율 확인: apiVideoId={} → SHORTS", apiVideoId);
+            log.debug("썸네일 비율 확인: apiVideoId={} → SHORTS", apiVideoId);
             return VideoType.SHORTS;
         }
 
-        log.info("일반 영상 확인: apiVideoId={} → VIDEO", apiVideoId);
+        log.debug("일반 영상 확인: apiVideoId={} → VIDEO", apiVideoId);
         return VideoType.VIDEO;
     }
 
     /**
-     * Shorts URL 유효성 확인
-     * https://www.youtube.com/shorts/{videoId} → 200 OK면 쇼츠
+     * Shorts URL 유효성 확인 (타임아웃: 연결 2초, 읽기 3초)
      */
     private boolean isShortsUrlValid(String apiVideoId) {
         try {
@@ -56,34 +53,30 @@ public class VideoTypeDetector {
             headers.set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
             HttpEntity<String> entity = new HttpEntity<>(headers);
 
-            ResponseEntity<String> response = restTemplate.exchange(
+            ResponseEntity<String> response = fastRestTemplate.exchange(
                     shortsUrl,
                     HttpMethod.HEAD,
                     entity,
                     String.class
             );
 
-            // 200 OK → 쇼츠 확정
             return response.getStatusCode() == HttpStatus.OK;
 
         } catch (HttpClientErrorException e) {
-            // 404, 301 등 → 일반 영상
             log.debug("Shorts URL 실패: apiVideoId={}, status={}", apiVideoId, e.getStatusCode());
             return false;
 
         } catch (Exception e) {
-            log.warn("Shorts URL 확인 중 예외: apiVideoId={}, error={}", apiVideoId, e.getMessage());
+            log.debug("Shorts URL 확인 타임아웃: apiVideoId={}, error={}", apiVideoId, e.getMessage());
             return false;
         }
     }
 
     /**
-     * 썸네일 비율로 쇼츠 판별
-     * 세로 비율 (height > width) → 쇼츠
+     * 썸네일 비율로 쇼츠 판별 (세로 > 가로 = 쇼츠)
      */
     private boolean isShortsAspectRatio(JsonNode thumbnailData) {
         try {
-            // high, medium, default 순으로 확인
             JsonNode high = thumbnailData.path("high");
             JsonNode medium = thumbnailData.path("medium");
             JsonNode defaultThumb = thumbnailData.path("default");
@@ -103,12 +96,7 @@ public class VideoTypeDetector {
                 return false;
             }
 
-            // 세로 비율 = 쇼츠
-            boolean isVertical = height > width;
-
-            log.debug("썸네일 비율: {}x{} → {}", width, height, isVertical ? "세로(쇼츠)" : "가로(일반)");
-
-            return isVertical;
+            return height > width;
 
         } catch (Exception e) {
             log.warn("썸네일 비율 파싱 실패: {}", e.getMessage());

--- a/src/main/java/com/knu/sosuso/capstone/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/config/RestTemplateConfig.java
@@ -1,14 +1,65 @@
 package com.knu.sosuso.capstone.global.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
+/**
+ * RestTemplate 설정
+ *
+ * 타임아웃 미설정 시 외부 서버 장애가 우리 서비스로 전파됨
+ * - YouTube 서버 지연 → 스레드 무한 대기 → 서비스 마비
+ */
+@Slf4j
 @Configuration
 public class RestTemplateConfig {
 
+    /**
+     * 기본 RestTemplate (YouTube API 등)
+     * - 연결: 5초
+     * - 읽기: 10초
+     */
     @Bean
+    @Primary
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);    // 5초
+        factory.setReadTimeout(10000);      // 10초
+
+        log.info("✅ RestTemplate 초기화: connectTimeout=5s, readTimeout=10s");
+        return new RestTemplate(factory);
+    }
+
+    /**
+     * AI 분석용 RestTemplate (FastAPI)
+     * - 연결: 5초
+     * - 읽기: 60초 (1분)
+     */
+    @Bean("aiRestTemplate")
+    public RestTemplate aiRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);     // 5초
+        factory.setReadTimeout(60000);      // 60초 (1분)
+
+        log.info("✅ AI RestTemplate 초기화: connectTimeout=5s, readTimeout=60s");
+        return new RestTemplate(factory);
+    }
+
+    /**
+     * 빠른 응답용 RestTemplate (Shorts URL 체크)
+     * - 연결: 2초
+     * - 읽기: 3초
+     */
+    @Bean("fastRestTemplate")
+    public RestTemplate fastRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(2000);    // 2초
+        factory.setReadTimeout(3000);       // 3초
+
+        log.info("✅ Fast RestTemplate 초기화: connectTimeout=2s, readTimeout=3s");
+        return new RestTemplate(factory);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,14 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 30
+      minimum-idle: 10
+      connection-timeout: 3000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      leak-detection-threshold: 30000
+      pool-name: SoSuSo-HikariCP
 
   jpa:
     hibernate:
@@ -15,6 +23,8 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+        generate_statistics: true
+    open-in-view: false
 
   security:
     oauth2:


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #158 
---
### 📌 요약
- 동시 사용자 증가 대비 서버 안정성 개선
  - DB 커넥션 풀 고갈 방지
  - 외부 API 장애 전파 차단
  - Cache Stampede 방지

### ✅ 작업 내용
- `application.yml` - HikariCP 설정 추가 (pool-size: 30, timeout: 3s)
- `RestTemplateConfig.java` - 타임아웃 설정 (연결 5초, 읽기 10초)
- `RestTemplateConfig.java` - fastRestTemplate Bean 추가 (URL 체크용)
- `RestTemplateConfig.java` - aiRestTemplate Bean 추가 (AI 모델 분석용)
- @Cacheable에 `sync = true` 추가
  - VideoDetailService: getOrProcessVideo, getVideoBasic
  - PopularVideoService: getPopularVideos
  - ChannelService: searchChannels
- 트랜잭션 구조 단순화

### 📚 참고 자료, 할 말
- 없습니다.