### PR TITLE
[FEATURE] URL 제외한 검색 키워드 로그 저장 기능 추가

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/video/controller/SearchController.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/controller/SearchController.java
@@ -2,7 +2,6 @@ package com.knu.sosuso.capstone.domain.video.controller;
 
 import com.knu.sosuso.capstone.domain.channel.dto.response.ChannelSearchResponse;
 import com.knu.sosuso.capstone.domain.channel.service.ChannelService;
-import com.knu.sosuso.capstone.domain.trending_search.entity.SearchLog;
 import com.knu.sosuso.capstone.domain.trending_search.repository.SearchLogRepository;
 import com.knu.sosuso.capstone.domain.video.dto.response.SearchResultPageResponse;
 import com.knu.sosuso.capstone.domain.video.service.VideoSearchService;
@@ -77,8 +76,7 @@ public class SearchController implements SearchControllerSwagger {
 
         log.info("채널 검색 요청: query={}", query);
 
-        // 검색 로그 저장
-        searchLogRepository.save(new SearchLog(query));
+        videoSearchService.logSearchKeyword(query);
 
         // 채널 검색 수행
         ChannelSearchResponse result = channelService.searchChannels(token, query);

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoSearchService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoSearchService.java
@@ -2,6 +2,8 @@ package com.knu.sosuso.capstone.domain.video.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.knu.sosuso.capstone.domain.trending_search.entity.SearchLog;
+import com.knu.sosuso.capstone.domain.trending_search.repository.SearchLogRepository;
 import com.knu.sosuso.capstone.domain.video.dto.response.SearchResultPageResponse;
 import com.knu.sosuso.capstone.domain.video.dto.response.VideoSummaryResponse;
 import com.knu.sosuso.capstone.domain.video.entity.VideoType;
@@ -45,6 +47,7 @@ public class VideoSearchService {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
     private final VideoProcessingService videoProcessingService;
+    private final SearchLogRepository searchLogRepository;
 
     /**
      * 동영상 검색 (쇼츠 제외)
@@ -409,6 +412,16 @@ public class VideoSearchService {
         } catch (Exception e) {
             log.error("Search API 응답 파싱 실패", e);
             throw new BusinessException(CommonError.DATA_PARSING_ERROR);
+        }
+    }
+
+    public void logSearchKeyword(String query) {
+        boolean isUrl = query.startsWith("https://")
+                || query.startsWith("http://")
+                || query.startsWith("www.");
+
+        if (!isUrl) {
+            searchLogRepository.save(new SearchLog(query));
         }
     }
 


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #161
---
### 📌 요약
- 검색 시 URL이 아닌 키워드만 검색어 로그 DB에 저장하는 기능 추가

### ✅ 작업 내용
- `VideoSearchService`에 `logSearchKeyword()` 메서드 구현
- `http://`, `https://`, `www.`로 시작하는 URL 패턴 제외 처리
- 순수 키워드만 `SearchLog` 엔티티로 저장

### 📚 참고 자료, 할 말
- 많은 사용자가 특정 영상 링크로 검색하는 경우, 해당 URL도 인기 검색어에 포함해야 하는지 고민함.
- 그러나 인기 검색어와 인기 영상은 성격이 다르다고 판단하여 **URL은 제외함**.
> **키워드 검색**: 사용자가 관심 있는 주제를 탐색하는 행위
> **URL 검색**: 특정 영상을 이미 알고 찾아오는 행위
- 인기 영상은 `VideoViewLog`에서 별도로 추적하고 있으므로, `SearchLog`는 순수 키워드만 저장하여 역할을 분리함.