### PR TITLE
[FEATURE] ShedLock 적용 및 N+1 쿼리 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation 'org.springframework:spring-aspects'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework:spring-aspects'
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/repository/VideoRepository.java
@@ -15,6 +15,11 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
     Optional<Video> findByApiVideoId(String apiVideoId);
 
     /**
+     * N+1 해결용: apiVideoId 리스트로 한 번에 조회
+     */
+    List<Video> findByApiVideoIdIn(List<String> apiVideoIds);
+
+    /**
      * 특정 시점 이전에 삭제 확인된 영상 조회 (하드 삭제용)
      */
     List<Video> findByDeletedTrueAndDeleteCheckedAtBefore(LocalDateTime dateTime);
@@ -39,5 +44,4 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
      * 미분석 영상 조회 (최근 업데이트 순, 상위 N개)
      */
     List<Video> findTop10ByAiAnalysisStatusOrderByUpdatedAtDesc(AIAnalysisStatus status);
-
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/PopularVideoService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/PopularVideoService.java
@@ -20,6 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * 인기 영상 관련 Facade 서비스
@@ -41,10 +44,7 @@ public class PopularVideoService {
      * 인기 영상 TOP N 조회
      * Caffeine 캐시 적용 (TTL: 60분)
      *
-     * @param token 사용자 토큰 (스크랩 여부 확인용)
-     * @param maxResults 조회할 영상 개수
-     * @return 인기 영상 리스트
-     * @throws BusinessException maxResults가 유효하지 않을 때
+     * N+1 쿼리 해결: IN 쿼리로 한 번에 조회
      */
     @Cacheable(value = "popularVideos", key = "#maxResults", sync = true)
     @Transactional(readOnly = true)
@@ -65,12 +65,27 @@ public class PopularVideoService {
                 return new ArrayList<>();
             }
 
+            // 1. apiVideoId 리스트 추출
+            List<String> apiVideoIds = topStats.getContent().stream()
+                    .map(VideoStats::getApiVideoId)
+                    .collect(Collectors.toList());
+
+            // 2. IN 쿼리로 한 번에 조회 (N+1 해결!)
+            List<Video> videos = videoRepository.findByApiVideoIdIn(apiVideoIds);
+
+            // 3. Map으로 변환 (빠른 조회용)
+            Map<String, Video> videoMap = videos.stream()
+                    .collect(Collectors.toMap(
+                            Video::getApiVideoId,
+                            Function.identity()
+                    ));
+
+            // 4. 순서 유지하면서 결과 생성
             List<VideoSummaryResponse> results = new ArrayList<>();
 
             for (VideoStats stats : topStats) {
                 try {
-                    Video video = videoRepository.findByApiVideoId(stats.getApiVideoId())
-                            .orElse(null);
+                    Video video = videoMap.get(stats.getApiVideoId());
 
                     if (video == null) {
                         log.warn("VideoStats에는 있지만 Video가 없음: apiVideoId={}",
@@ -87,7 +102,6 @@ public class PopularVideoService {
                 } catch (Exception e) {
                     log.error("인기 영상 변환 실패: apiVideoId={}, error={}",
                             stats.getApiVideoId(), e.getMessage(), e);
-                    // 하나의 영상 변환 실패가 전체에 영향을 주지 않도록 continue
                 }
             }
 
@@ -106,8 +120,6 @@ public class PopularVideoService {
     /**
      * 인기도 점수 재계산 (배치 작업)
      * Scheduler에서 호출
-     *
-     * @return 업데이트된 영상 개수
      */
     public int recalculatePopularity() {
         try {

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoProcessingService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoProcessingService.java
@@ -22,6 +22,7 @@ import com.knu.sosuso.capstone.global.exception.error.VideoError;
 import com.knu.sosuso.capstone.global.service.mapper.VideoMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.scheduling.annotation.Async;
@@ -203,10 +204,20 @@ public class VideoProcessingService {
      * 스케줄러: 1분마다 미분석 영상 처리
      * - PENDING 상태 영상 최대 10개
      * - 최근 조회순 우선
+     *
+     * @SchedulerLock 설정:
+     * - name: 락 이름 (테이블에 저장됨)
+     * - lockAtLeastFor: 최소 락 유지 시간 (30초) → 빠르게 끝나도 30초간 다른 서버 실행 방지
+     * - lockAtMostFor: 최대 락 유지 시간 (5분) → 서버 죽어도 5분 후 자동 해제
      */
+    @SchedulerLock(
+            name = "processUnanalyzedVideos",
+            lockAtLeastFor = "30s",
+            lockAtMostFor = "5m"
+    )
     @Scheduled(fixedDelayString = "#{${ai.batch.interval.ms:60000}}")
     public void processUnanalyzedVideos() {
-        log.info("🔄 미분석 영상 배치 처리 시작");
+        log.info("🔄 미분석 영상 배치 처리 시작 (ShedLock 적용)");
 
         try {
             int batchSize = appConfig.getAiBatchSize();

--- a/src/main/java/com/knu/sosuso/capstone/global/config/ShedLockConfig.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/config/ShedLockConfig.java
@@ -1,0 +1,31 @@
+package com.knu.sosuso.capstone.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+/**
+ * ShedLock 설정
+ *
+ * 분산 환경(서버 2대 이상)에서 스케줄러가 중복 실행되는 것을 방지
+ * → AI 분석 비용 절감, 데이터 정합성 보장
+ */
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()  // DB 시간 사용 (서버 간 시간 차이 문제 방지)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/knu/sosuso/capstone/global/scheduler/PopularityScheduler.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/scheduler/PopularityScheduler.java
@@ -3,6 +3,7 @@ package com.knu.sosuso.capstone.global.scheduler;
 import com.knu.sosuso.capstone.domain.video.service.PopularVideoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -24,9 +25,14 @@ public class PopularityScheduler {
      * cron: 초 분 시 일 월 요일
      * "0 0 * * * *" = 매 시간 00분 00초
      */
+    @SchedulerLock(
+            name = "calculatePopularity",
+            lockAtLeastFor = "30s",
+            lockAtMostFor = "10m"
+    )
     @Scheduled(cron = "0 0 * * * *")
     public void calculatePopularity() {
-        log.info("⏰ [스케줄] 인기도 점수 계산 시작");
+        log.info("⏰ [스케줄] 인기도 점수 계산 시작 (ShedLock 적용)");
 
         try {
             int updatedCount = popularVideoService.recalculatePopularity();
@@ -41,9 +47,14 @@ public class PopularityScheduler {
      * 매일 새벽 3시에 오래된 로그 삭제
      * cron: "0 0 3 * * *" = 매일 03:00:00
      */
+    @SchedulerLock(
+            name = "cleanupPopularityLogs",
+            lockAtLeastFor = "30s",
+            lockAtMostFor = "10m"
+    )
     @Scheduled(cron = "0 0 3 * * *")
     public void cleanupLogs() {
-        log.info("🗑️ [스케줄] 오래된 조회 로그 삭제 시작");
+        log.info("🗑️ [스케줄] 오래된 조회 로그 삭제 시작 (ShedLock 적용)");
 
         try {
             popularVideoService.cleanupOldLogs();

--- a/src/main/java/com/knu/sosuso/capstone/global/scheduler/VideoCleanupService.java
+++ b/src/main/java/com/knu/sosuso/capstone/global/scheduler/VideoCleanupService.java
@@ -8,6 +8,7 @@ import com.knu.sosuso.capstone.domain.video.service.VideoProcessingService;
 import com.knu.sosuso.capstone.global.config.AppConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,10 +36,15 @@ public class VideoCleanupService {
      * 오래된 삭제 영상 하드 삭제
      * 매달 1일 새벽 3시에 실행
      */
+    @SchedulerLock(
+            name = "cleanupOldDeletedVideos",
+            lockAtLeastFor = "1m",
+            lockAtMostFor = "30m"
+    )
     @Scheduled(cron = "0 0 3 1 * *")  // 매달 1일 03:00
     @Transactional
     public void cleanupOldDeletedVideos() {
-        log.info("=== 오래된 삭제 영상 정리 시작 ===");
+        log.info("=== 오래된 삭제 영상 정리 시작 (ShedLock 적용) ===");
 
         LocalDateTime retentionThreshold = LocalDateTime.now()
                 .minusDays(appConfig.getDataRetentionDays());
@@ -100,10 +106,15 @@ public class VideoCleanupService {
      * 스크랩된 영상의 메타데이터 정기 갱신
      * 매일 새벽 2시에 실행
      */
+    @SchedulerLock(
+            name = "updateScrappedVideosMetadata",
+            lockAtLeastFor = "1m",
+            lockAtMostFor = "30m"
+    )
     @Scheduled(cron = "0 0 2 * * *")  // 매일 02:00
     @Transactional
     public void updateScrappedVideosMetadata() {
-        log.info("=== 스크랩된 영상 메타데이터 갱신 시작 ===");
+        log.info("=== 스크랩된 영상 메타데이터 갱신 시작 (ShedLock 적용) ===");
 
         LocalDateTime updateThreshold = LocalDateTime.now()
                 .minusDays(appConfig.getMetadataUpdateDays());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,11 @@ spring:
   cache:
     type: caffeine
 
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
+
 jwt:
   secret: ${JWT_SECRET}
 

--- a/src/main/resources/db/migration/V1__create_shedlock_table.sql
+++ b/src/main/resources/db/migration/V1__create_shedlock_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS shedlock (
+                                        name VARCHAR(64) NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    locked_by VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #160 
---
### 📌 요약
- ShedLock과 Flyway 마이그레이션을 설정합니다. 5개 스케줄러 @SchedulerLock 적용하며, N+1 쿼리 최적화를 진행합니다.

### ✅ 작업 내용
- **ShedLock 및 Flyway 설정**
  - `build.gradle`: shedlock, flyway 의존성 추가
  - `application.yml`: flyway 설정 추가
  - `ShedLockConfig.java`: LockProvider Bean 등록
  - `V1__create_shedlock_table.sql`: Flyway 마이그레이션 스크립트 추가

- **스케줄러 @SchedulerLock 적용**
  - `VideoProcessingService`: AI 분석 스케줄러 락 적용
  - `PopularityScheduler`: 인기도 계산, 로그 삭제 스케줄러 락 적용
  - `VideoCleanupService`: 영상 정리, 메타데이터 갱신 스케줄러 락 적용

- **N+1 쿼리 최적화**
  - `VideoRepository`: findByApiVideoIdIn() 메서드 추가
  - `PopularVideoService`: 개별 조회 → IN 쿼리 배치 조회로 변경


### 📚 참고 자료, 할 말
- 팀원 수동 SQL 실행 불필요, 시작 시 자동 마이그레이션