### PR TITLE
[REFACTOR] 트랜잭션 내 HTTP 호출 분리로 DB 커넥션 점유 시간 최소화

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/detail/service/VideoDetailService.java
@@ -60,20 +60,21 @@ public class VideoDetailService {
     public Video getOrProcessVideo(String apiVideoId) {
         log.info("📺 영상 엔티티 조회: apiVideoId={}", apiVideoId);
 
-        // 1. DB에서 먼저 찾기
         Optional<Video> existingVideo = videoRepository.findByApiVideoId(apiVideoId);
 
         Video video;
         if (existingVideo.isPresent()) {
-            // ✅ 기존 영상: 자체 처리
             video = existingVideo.get();
 
             if (shouldCheckDeletion(video)) {
-                checkAndUpdateDeletionStatus(video);
+                boolean isDeleted = videoService.checkAndUpdateDeletionStatus(video);
+                if (isDeleted) {
+                    throw new BusinessException(VideoError.VIDEO_DELETED);
+                }
             }
 
             if (shouldUpdateMetadata(video)) {
-                updateMetadata(video);
+                videoService.refreshMetadata(video);
             }
 
             log.info("✅ 기존 영상 조회: apiVideoId={}", apiVideoId);
@@ -662,40 +663,5 @@ public class VideoDetailService {
         LocalDateTime updateThreshold = LocalDateTime.now()
                 .minusDays(appConfig.getMetadataUpdateDays());
         return video.getLastMetadataUpdatedAt().isBefore(updateThreshold);
-    }
-
-    @Transactional
-    public void checkAndUpdateDeletionStatus(Video video) {
-        boolean isDeleted = videoService.checkIfVideoDeleted(video.getApiVideoId());
-        if (isDeleted) {
-            video.setDeleted(true);
-            video.setDeleteCheckedAt(LocalDateTime.now());
-            videoRepository.save(video);
-            throw new BusinessException(VideoError.VIDEO_DELETED);
-        }
-        video.setDeleteCheckedAt(LocalDateTime.now());
-        videoRepository.save(video);
-    }
-
-    @Transactional
-    public void updateMetadata(Video video) {
-        try {
-            VideoApiResponse videoInfo = videoService.getVideoInfo(video.getApiVideoId());
-
-            video.setViewCount(videoInfo.viewCount());
-            video.setLikeCount(videoInfo.likeCount());
-            video.setCommentCount(videoInfo.commentCount());
-            video.setLastMetadataUpdatedAt(LocalDateTime.now());
-            video.setMetadataUpdateCount(video.getMetadataUpdateCount() + 1);
-
-            videoRepository.save(video);
-
-            log.info("✅ 메타데이터 갱신 완료: apiVideoId={}, updateCount={}",
-                    video.getApiVideoId(), video.getMetadataUpdateCount());
-
-        } catch (Exception e) {
-            log.error("❌ 메타데이터 갱신 실패: apiVideoId={}, error={}",
-                    video.getApiVideoId(), e.getMessage());
-        }
     }
 }

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoProcessingService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoProcessingService.java
@@ -136,7 +136,6 @@ public class VideoProcessingService {
     /**
      * 비디오 처리 메인 진입점 (검색용)
      */
-    @Transactional
     public Video processVideoToSearchResult(String apiVideoId) {
         if (apiVideoId == null || apiVideoId.trim().isEmpty()) {
             throw new BusinessException(VideoError.VIDEO_ID_REQUIRED);
@@ -147,9 +146,8 @@ public class VideoProcessingService {
         Optional<Video> existingVideo = videoRepository.findByApiVideoId(apiVideoId);
 
         if (existingVideo.isPresent()) {
-            return handleExistingVideoWithTransaction(existingVideo.get());
+            return handleExistingVideo(existingVideo.get());
         } else {
-            // 쓰기 작업은 별도 트랜잭션
             return processNewVideo(apiVideoId, VideoType.VIDEO);
         }
     }
@@ -157,27 +155,19 @@ public class VideoProcessingService {
     /**
      * 기존 영상 처리 (검색용) - 쓰기 작업 분리
      */
-    @Transactional
-    public Video handleExistingVideoWithTransaction(Video video) {
+    public Video handleExistingVideo(Video video) {
         String apiVideoId = video.getApiVideoId();
 
-        // 삭제 확인
         if (shouldCheckDeletion(video)) {
-            boolean isDeleted = videoService.checkIfVideoDeleted(apiVideoId);
+            boolean isDeleted = videoService.checkAndUpdateDeletionStatus(video);
             if (isDeleted) {
-                video.setDeleted(true);
-                video.setDeleteCheckedAt(LocalDateTime.now());
-                videoRepository.save(video);
                 throw new BusinessException(VideoError.VIDEO_DELETED);
             }
-            video.setDeleteCheckedAt(LocalDateTime.now());
-            videoRepository.save(video);
         }
 
-        // 메타데이터 갱신
         if (shouldUpdateMetadata(video)) {
             log.info("메타데이터 갱신 필요: apiVideoId={}", apiVideoId);
-            updateMetadataInternal(video);
+            videoService.refreshMetadata(video);
         }
 
         return video;
@@ -411,82 +401,9 @@ public class VideoProcessingService {
      * - AI 분석은 하지 않음
      */
     @Async("videoProcessingExecutor")
-    @Transactional
     public void updateMetadata(Long videoId, String apiVideoId) {
         log.info("📊 메타데이터 갱신 시작: videoId={}, apiVideoId={}", videoId, apiVideoId);
-
-        try {
-            // 1. YouTube API에서 최신 정보 가져오기
-            VideoApiResponse latestInfo = videoService.getVideoInfo(apiVideoId);
-
-            // 2. DB에서 비디오 조회
-            Video video = videoRepository.findById(videoId)
-                    .orElseThrow(() -> new BusinessException(VideoError.VIDEO_NOT_FOUND));
-
-            // 3. 메타데이터만 업데이트
-            video.setTitle(latestInfo.title());
-            video.setDescription(latestInfo.description());
-            video.setViewCount(latestInfo.viewCount());
-            video.setLikeCount(latestInfo.likeCount());
-            video.setCommentCount(latestInfo.commentCount());
-            video.setThumbnailUrl(latestInfo.thumbnailUrl());
-            video.setSubscriberCount(latestInfo.subscriberCount());
-
-            // 갱신 시간 기록
-            video.setLastMetadataUpdatedAt(LocalDateTime.now());
-            video.setMetadataUpdateCount(video.getMetadataUpdateCount() + 1);
-
-            videoRepository.save(video);
-
-            log.info("✅ 메타데이터 갱신 완료: videoId={}, 갱신 횟수={}",
-                    videoId, video.getMetadataUpdateCount());
-
-        } catch (BusinessException e) {
-            if (e.getError() == VideoError.VIDEO_NOT_FOUND) {
-                // YouTube에서 삭제됨
-                log.warn("⚠️ YouTube에서 영상 삭제됨: apiVideoId={}", apiVideoId);
-
-                try {
-                    Video video = videoRepository.findById(videoId).orElse(null);
-                    if (video != null) {
-                        video.setDeleted(true);
-                        video.setDeleteCheckedAt(LocalDateTime.now());
-                        videoRepository.save(video);
-                        log.info("🗑️ 영상 삭제 플래그 설정: videoId={}", videoId);
-                    }
-                } catch (Exception ex) {
-                    log.error("❌ 삭제 플래그 설정 실패: {}", ex.getMessage());
-                }
-            } else {
-                throw e;
-            }
-        } catch (Exception e) {
-            log.error("❌ 메타데이터 갱신 실패: videoId={}, apiVideoId={}, error={}",
-                    videoId, apiVideoId, e.getMessage(), e);
-            throw new BusinessException(CommonError.VIDEO_PROCESSING_ERROR);
-        }
-    }
-
-    /**
-     * 메타데이터 갱신 (내부용, 이미 트랜잭션 안)
-     */
-    private void updateMetadataInternal(Video video) {
-        try {
-            VideoApiResponse videoInfo = videoService.getVideoInfo(video.getApiVideoId());
-
-            video.setViewCount(videoInfo.viewCount());
-            video.setLikeCount(videoInfo.likeCount());
-            video.setCommentCount(videoInfo.commentCount());
-            video.setLastMetadataUpdatedAt(LocalDateTime.now());
-            video.setMetadataUpdateCount(video.getMetadataUpdateCount() + 1);
-
-            videoRepository.save(video);
-
-            log.info("메타데이터 갱신 완료: apiVideoId={}", video.getApiVideoId());
-
-        } catch (Exception e) {
-            log.error("메타데이터 갱신 실패: apiVideoId={}", video.getApiVideoId(), e);
-        }
+        videoService.refreshMetadataById(videoId, apiVideoId);
     }
 
     /**

--- a/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/video/service/VideoService.java
@@ -22,7 +22,6 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.LocalDateTime;
-import java.util.regex.Pattern;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -36,6 +35,173 @@ public class VideoService {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final VideoRepository videoRepository;
+
+    // ========================================
+    // 1. 메타데이터 갱신 (HTTP + 저장 통합)
+    // ========================================
+
+    /**
+     * ✅ 메타데이터 갱신 (HTTP 호출 분리)
+     * - HTTP 호출은 트랜잭션 밖
+     * - DB 저장만 트랜잭션 안
+     *
+     * @param video 갱신할 Video 엔티티
+     */
+    public void refreshMetadata(Video video) {
+        try {
+            // 1. HTTP 호출 (트랜잭션 밖) - 커넥션 점유 X
+            VideoApiResponse videoInfo = getVideoInfo(video.getApiVideoId());
+
+            // 2. DB 저장 (트랜잭션 안) - 커넥션 0.01초만
+            saveMetadataUpdate(video, videoInfo);
+
+            log.info("✅ 메타데이터 갱신 완료: apiVideoId={}, updateCount={}",
+                    video.getApiVideoId(), video.getMetadataUpdateCount() + 1);
+
+        } catch (BusinessException e) {
+            if (e.getError() == VideoError.VIDEO_NOT_FOUND) {
+                // YouTube에서 삭제됨 → 삭제 플래그 설정
+                log.warn("⚠️ YouTube에서 영상 삭제됨: apiVideoId={}", video.getApiVideoId());
+                markAsDeleted(video);
+            } else {
+                throw e;
+            }
+        } catch (Exception e) {
+            log.error("❌ 메타데이터 갱신 실패: apiVideoId={}, error={}",
+                    video.getApiVideoId(), e.getMessage());
+        }
+    }
+
+    /**
+     * ✅ 메타데이터 갱신 (ID 기반 - 스케줄러용)
+     */
+    public void refreshMetadataById(Long videoId, String apiVideoId) {
+        try {
+            // 1. HTTP 호출 (트랜잭션 밖)
+            VideoApiResponse videoInfo = getVideoInfo(apiVideoId);
+
+            // 2. DB 저장 (트랜잭션 안)
+            saveMetadataUpdateById(videoId, videoInfo);
+
+            log.info("✅ 메타데이터 갱신 완료: videoId={}", videoId);
+
+        } catch (BusinessException e) {
+            if (e.getError() == VideoError.VIDEO_NOT_FOUND) {
+                log.warn("⚠️ YouTube에서 영상 삭제됨: apiVideoId={}", apiVideoId);
+                markAsDeletedById(videoId);
+            } else {
+                throw e;
+            }
+        } catch (Exception e) {
+            log.error("❌ 메타데이터 갱신 실패: videoId={}, error={}", videoId, e.getMessage());
+            throw new BusinessException(CommonError.VIDEO_PROCESSING_ERROR);
+        }
+    }
+
+    /**
+     * 메타데이터 저장 (트랜잭션)
+     */
+    @Transactional
+    public void saveMetadataUpdate(Video video, VideoApiResponse videoInfo) {
+        video.setViewCount(videoInfo.viewCount());
+        video.setLikeCount(videoInfo.likeCount());
+        video.setCommentCount(videoInfo.commentCount());
+        video.setLastMetadataUpdatedAt(LocalDateTime.now());
+        video.setMetadataUpdateCount(video.getMetadataUpdateCount() + 1);
+
+        videoRepository.save(video);
+    }
+
+    /**
+     * 메타데이터 저장 - ID 기반 (트랜잭션)
+     */
+    @Transactional
+    public void saveMetadataUpdateById(Long videoId, VideoApiResponse videoInfo) {
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new BusinessException(VideoError.VIDEO_NOT_FOUND));
+
+        video.setTitle(videoInfo.title());
+        video.setDescription(videoInfo.description());
+        video.setViewCount(videoInfo.viewCount());
+        video.setLikeCount(videoInfo.likeCount());
+        video.setCommentCount(videoInfo.commentCount());
+        video.setThumbnailUrl(videoInfo.thumbnailUrl());
+        video.setSubscriberCount(videoInfo.subscriberCount());
+        video.setLastMetadataUpdatedAt(LocalDateTime.now());
+        video.setMetadataUpdateCount(video.getMetadataUpdateCount() + 1);
+
+        videoRepository.save(video);
+    }
+
+    // ========================================
+    // 2. 삭제 확인 (HTTP + 저장 통합)
+    // ========================================
+
+    /**
+     * ✅ 삭제 여부 확인 및 상태 업데이트 (HTTP 호출 분리)
+     * - HTTP 호출은 트랜잭션 밖
+     * - DB 저장만 트랜잭션 안
+     *
+     * @param video 확인할 Video 엔티티
+     * @return true면 삭제됨
+     */
+    public boolean checkAndUpdateDeletionStatus(Video video) {
+        // 1. HTTP 호출 (트랜잭션 밖) - 커넥션 점유 X
+        boolean isDeleted = checkIfVideoDeleted(video.getApiVideoId());
+
+        // 2. DB 저장 (트랜잭션 안) - 커넥션 0.01초만
+        saveDeletionStatus(video, isDeleted);
+
+        if (isDeleted) {
+            log.info("🗑️ 영상 삭제 확인: apiVideoId={}", video.getApiVideoId());
+        }
+
+        return isDeleted;
+    }
+
+    /**
+     * 삭제 상태 저장 (트랜잭션)
+     */
+    @Transactional
+    public void saveDeletionStatus(Video video, boolean isDeleted) {
+        if (isDeleted) {
+            video.setDeleted(true);
+        }
+        video.setDeleteCheckedAt(LocalDateTime.now());
+        videoRepository.save(video);
+    }
+
+    /**
+     * 삭제 플래그 설정 (트랜잭션)
+     */
+    @Transactional
+    public void markAsDeleted(Video video) {
+        video.setDeleted(true);
+        video.setDeleteCheckedAt(LocalDateTime.now());
+        videoRepository.save(video);
+    }
+
+    /**
+     * 삭제 플래그 설정 - ID 기반 (트랜잭션)
+     */
+    @Transactional
+    public void markAsDeletedById(Long videoId) {
+        try {
+            Video video = videoRepository.findById(videoId).orElse(null);
+            if (video != null) {
+                video.setDeleted(true);
+                video.setDeleteCheckedAt(LocalDateTime.now());
+                videoRepository.save(video);
+                log.info("🗑️ 영상 삭제 플래그 설정: videoId={}", videoId);
+            }
+        } catch (Exception e) {
+            log.error("❌ 삭제 플래그 설정 실패: videoId={}, error={}", videoId, e.getMessage());
+        }
+    }
+
+    // ========================================
+    // 3. YouTube API 호출 (기존 유지)
+    // ========================================
 
     /**
      * YouTube API로 비디오 정보 조회
@@ -75,11 +241,54 @@ public class VideoService {
         } catch (RestClientException e) {
             log.error("YouTube API 네트워크 에러: {}", e.getMessage());
             throw new BusinessException(CommonError.YOUTUBE_API_ERROR);
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
             log.error("비디오 정보 조회 중 예상치 못한 오류: {}", e.getMessage());
             throw new BusinessException(CommonError.INTERNAL_SERVER_ERROR);
         }
     }
+
+    /**
+     * YouTube API로 영상 삭제 여부 확인
+     */
+    public boolean checkIfVideoDeleted(String apiVideoId) {
+        try {
+            String apiUrl = UriComponentsBuilder
+                    .fromUriString(YOUTUBE_VIDEOS_API_URL)
+                    .queryParam("part", "id")
+                    .queryParam("id", apiVideoId)
+                    .queryParam("key", apiConfig.getKey())
+                    .build(false)
+                    .toUriString();
+
+            String jsonResponse = restTemplate.getForObject(apiUrl, String.class);
+            JsonNode rootNode = objectMapper.readTree(jsonResponse);
+
+            JsonNode items = rootNode.path("items");
+            boolean isDeleted = items.isEmpty();
+
+            if (isDeleted) {
+                log.info("영상 삭제 확인됨: apiVideoId={}", apiVideoId);
+            }
+
+            return isDeleted;
+
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode().is4xxClientError()) {
+                log.error("YouTube API 에러: {}", e.getMessage());
+                return false;
+            }
+            throw e;
+        } catch (Exception e) {
+            log.error("영상 삭제 여부 확인 실패: apiVideoId={}, error={}", apiVideoId, e.getMessage());
+            return false;
+        }
+    }
+
+    // ========================================
+    // 4. 비디오 저장 (기존 유지)
+    // ========================================
 
     /**
      * 메타데이터만 저장 (댓글 없는 경우)
@@ -171,51 +380,8 @@ public class VideoService {
         }
     }
 
-    /**
-     * YouTube API로 영상 삭제 여부 확인
-     */
-    public boolean checkIfVideoDeleted(String apiVideoId) {
-        try {
-            String apiUrl = UriComponentsBuilder
-                    .fromUriString(YOUTUBE_VIDEOS_API_URL)
-                    .queryParam("part", "id")
-                    .queryParam("id", apiVideoId)
-                    .queryParam("key", apiConfig.getKey())
-                    .build(false)
-                    .toUriString();
-
-            String jsonResponse = restTemplate.getForObject(apiUrl, String.class);
-            JsonNode rootNode = objectMapper.readTree(jsonResponse);
-
-            JsonNode items = rootNode.path("items");
-            boolean isDeleted = items.isEmpty();
-
-            if (isDeleted) {
-                log.info("영상 삭제 확인됨: apiVideoId={}", apiVideoId);
-            }
-
-            return isDeleted;
-
-        } catch (HttpClientErrorException e) {
-            if (e.getStatusCode().is4xxClientError()) {
-                log.error("YouTube API 에러: {}", e.getMessage());
-                return false;
-            }
-            throw e;
-        } catch (Exception e) {
-            log.error("영상 삭제 여부 확인 실패: apiVideoId={}, error={}", apiVideoId, e.getMessage());
-            return false;
-        }
-    }
-
     // ==================== Private 헬퍼 메서드 ====================
 
-    /**
-     * 유튜브에 해당 영상 데이터를 요청
-     *
-     * @param videoId YouTube 비디오 ID
-     * @return YouTube API로부터 받은 JSON 응답
-     */
     private String getVideoData(String videoId) {
         String apiUrl = UriComponentsBuilder.fromUriString(YOUTUBE_VIDEOS_API_URL)
                 .queryParam("part", "snippet,statistics")
@@ -228,12 +394,6 @@ public class VideoService {
         return restTemplate.getForObject(apiUrl, String.class);
     }
 
-    /**
-     * 유튜브로부터 채널 데이터를 받아옴
-     *
-     * @param channelId YouTube 채널 ID
-     * @return YouTube API로부터 받은 채널 JSON 응답
-     */
     private String getChannelData(String channelId) {
         String apiUrl = UriComponentsBuilder.fromUriString(YOUTUBE_CHANNELS_API_URL)
                 .queryParam("part", "snippet,statistics")
@@ -245,13 +405,6 @@ public class VideoService {
         return restTemplate.getForObject(apiUrl, String.class);
     }
 
-    /**
-     * 유튜브로부터 받은 데이터를 VideoApiResponse로 변환
-     *
-     * @param videoItem          YouTube API의 비디오 아이템 JSON
-     * @param channelItem        YouTube API의 채널 아이템 JSON
-     * @return 변환된 VideoApiResponse 객체
-     */
     private VideoApiResponse buildVideoResponse(JsonNode videoItem, JsonNode channelItem) {
         JsonNode snippet = videoItem.get("snippet");
         JsonNode statistics = videoItem.get("statistics");
@@ -296,14 +449,10 @@ public class VideoService {
         return "";
     }
 
-    /**
-     * 타입별 썸네일 선택
-     */
     private String extractThumbnailByType(JsonNode thumbnails, VideoType videoType) {
         if (thumbnails == null) return "";
 
         if (videoType == VideoType.SHORTS) {
-            // 쇼츠: 작은 크기 우선 (세로 비율)
             if (thumbnails.has("medium")) {
                 return thumbnails.get("medium").get("url").asText();
             }
@@ -311,7 +460,6 @@ public class VideoService {
                 return thumbnails.get("default").get("url").asText();
             }
         } else {
-            // 일반 영상: 큰 크기 우선 (가로 비율)
             if (thumbnails.has("standard")) {
                 return thumbnails.get("standard").get("url").asText();
             }
@@ -320,7 +468,6 @@ public class VideoService {
             }
         }
 
-        // 기본값
         if (thumbnails.has("medium")) {
             return thumbnails.get("medium").get("url").asText();
         }


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #164 
---
### 📌 요약
- 트랜잭션 내 HTTP 호출을 분리하여 DB 커넥션 점유 시간을 최소화합니다.

### ✅ 작업 내용
- **VideoService.java**
  - `refreshMetadata()`: 메타데이터 갱신 (HTTP → DB 분리)
  - `refreshMetadataById()`: 스케줄러용 메타데이터 갱신
  - `checkAndUpdateDeletionStatus()`: 삭제 확인 (HTTP → DB 분리)
  - `saveMetadataUpdate()`, `saveDeletionStatus()` 등 @Transactional 저장 메서드

- **VideoDetailService.java**
  - 중복 메서드 삭제: `checkAndUpdateDeletionStatus()`, `updateMetadata()`
  - `getOrProcessVideo()`: VideoService 호출로 변경

- **VideoProcessingService.java**
  - `handleExistingVideo()`: VideoService 호출로 변경
  - `updateMetadata()`: 60줄 → 3줄로 단순화

### 📚 참고 자료, 할 말
- 없습니다.