### PR TITLE
[REFACTOR] 인기 검색어 집계 범위 및 배치 주기 조정

### DIFF
--- a/src/main/java/com/knu/sosuso/capstone/domain/trending_search/service/TrendingSearchBatchService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/trending_search/service/TrendingSearchBatchService.java
@@ -31,7 +31,7 @@ public class TrendingSearchBatchService {
     private EntityManager em;
 
     @Transactional
-    @Scheduled(cron = "0 */10 * * * *")
+    @Scheduled(cron = "0 0 * * * *")
     public synchronized void updateTrendingKeywords() {
 
         log.info("인기 검색어 배치 실행 시작");

--- a/src/main/java/com/knu/sosuso/capstone/domain/trending_search/service/TrendingSearchBatchService.java
+++ b/src/main/java/com/knu/sosuso/capstone/domain/trending_search/service/TrendingSearchBatchService.java
@@ -59,9 +59,9 @@ public class TrendingSearchBatchService {
         em.clear();
 
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime oneHourAgo = now.minusHours(4);
+        LocalDateTime oneWeekAgo = now.minusHours(4);
 
-        List<KeywordCount> topKeywords = searchLogRepository.findTopKeywordsSince(oneHourAgo, PageRequest.of(0, 10));
+        List<KeywordCount> topKeywords = searchLogRepository.findTopKeywordsSince(oneWeekAgo, PageRequest.of(0, 10));
 
         for (KeywordCount count : topKeywords) {
             TrendingKeyword trending = TrendingKeyword.builder()


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #166
---
### 📌 요약
- 인기 검색어 배치 집계 범위 및 실행 주기 조정

### ✅ 작업 내용
- 인기 검색어 집계 범위를 4시간 → 1주일로 변경
- 배치 실행 주기를 10분 → 1시간으로 변경

### 📚 참고 자료, 할 말
- 4시간 범위는 트렌드 파악에 너무 짧아 1주일로 확장
- 1주일 데이터는 10분 간격으로 크게 변하지 않으므로 배치 주기도 1시간으로 조정하여 리소스 절약